### PR TITLE
Add Discord auth skeleton site

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,8 @@
 </head>
 <body>
   <h1>Welcome to the Pyro Freelancer Corps</h1>
-  <p>More content coming soon. Stay frosty, mate.</p>
+  <p>This is a public landing page.</p>
+  <a class="login" href="/auth/discord">Login with Discord</a>
   <script src="script.js"></script>
 </body>
 </html>

--- a/member.html
+++ b/member.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Member Area</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Member Area</h1>
+  <p>If you can see this, you are logged in via Discord.</p>
+  <a href="/logout">Logout</a>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,10 +1,17 @@
 {
-    "name": "Pyro Freelancer Corps",
-    "version": "1.0.0",
-    "main": "index.js",
-    "scripts": {
-        "test": "echo \"No tests yet, mate.\""
-      },      
-    "license": "ISC"
+  "name": "Pyro Freelancer Corps",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests yet, mate.\""
+  },
+  "license": "ISC",
+  "dependencies": {
+    "express": "^4.18.2",
+    "express-session": "^1.17.3",
+    "passport": "^0.6.0",
+    "passport-discord": "^1.0.0",
+    "dotenv": "^16.0.3"
   }
-  
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,72 @@
+const express = require('express');
+const session = require('express-session');
+const passport = require('passport');
+const DiscordStrategy = require('passport-discord').Strategy;
+require('dotenv').config();
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+const scopes = ['identify'];
+
+passport.serializeUser((user, done) => {
+  done(null, user);
+});
+
+passport.deserializeUser((obj, done) => {
+  done(null, obj);
+});
+
+passport.use(
+  new DiscordStrategy(
+    {
+      clientID: process.env.DISCORD_CLIENT_ID,
+      clientSecret: process.env.DISCORD_CLIENT_SECRET,
+      callbackURL: process.env.DISCORD_CALLBACK_URL || 'http://localhost:3000/auth/discord/callback',
+      scope: scopes,
+    },
+    (accessToken, refreshToken, profile, done) => {
+      // For now just pass the profile along
+      process.nextTick(() => done(null, profile));
+    }
+  )
+);
+
+app.use(
+  session({
+    secret: process.env.SESSION_SECRET || 'supersecret',
+    resave: false,
+    saveUninitialized: false,
+  })
+);
+
+app.use(passport.initialize());
+app.use(passport.session());
+app.use(express.static(__dirname));
+
+function checkAuth(req, res, next) {
+  if (req.isAuthenticated()) return next();
+  res.redirect('/');
+}
+
+app.get('/auth/discord', passport.authenticate('discord'));
+
+app.get(
+  '/auth/discord/callback',
+  passport.authenticate('discord', { failureRedirect: '/' }),
+  (req, res) => {
+    res.redirect('/member');
+  }
+);
+
+app.get('/logout', (req, res) => {
+  req.logout(() => {
+    res.redirect('/');
+  });
+});
+
+app.get('/member', checkAuth, (req, res) => {
+  res.sendFile(__dirname + '/member.html');
+});
+
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/style.css
+++ b/style.css
@@ -1,8 +1,16 @@
 body {
-    font-family: sans-serif;
-    background-color: #111;
-    color: #eee;
-    text-align: center;
-    padding: 5rem;
-  }
-  
+  font-family: sans-serif;
+  background-color: #111;
+  color: #eee;
+  text-align: center;
+  padding: 5rem;
+}
+
+a.login {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  background: #5865f2;
+  color: white;
+  text-decoration: none;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- create Express server with Discord OAuth
- add member-only page
- update landing page with login button
- style login link
- setup package.json with dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684050c1fce4832db85fa5892d924fbd