### PR TITLE
Fix logout path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/server.js
+++ b/server.js
@@ -42,7 +42,6 @@ app.use(
 
 app.use(passport.initialize());
 app.use(passport.session());
-app.use(express.static(__dirname));
 
 function checkAuth(req, res, next) {
   if (req.isAuthenticated()) return next();
@@ -68,5 +67,8 @@ app.get('/logout', (req, res) => {
 app.get('/member', checkAuth, (req, res) => {
   res.sendFile(__dirname + '/member.html');
 });
+
+// Serve static files (HTML, CSS, client-side JS)
+app.use(express.static(__dirname));
 
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- ensure Express routes handle `/logout` before the static middleware
- ignore `node_modules` in git

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684054c2bfe8832d8c6850daaeeb7b89