### PR TITLE
Implement protected member page with Discord login button

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -152,5 +152,94 @@ Each "agent" refers to a key component or responsibility in the system.
 
 ---
 
+# 🧪 Testing Guide for PFC Web App
+
+This guide provides instructions on how to test the PFC web application, particularly after implementing Discord authentication and protecting routes.
+
+---
+
+## 🔍 Testing Objectives
+
+* Verify Discord OAuth2 flow works correctly.
+* Confirm protected pages are inaccessible without authentication.
+* Ensure valid sessions allow access to protected content.
+* Validate backend routes with unit and integration tests.
+
+---
+
+## ✅ Manual Testing Steps
+
+### 1. Discord Login Flow
+
+* Go to `/api/auth/signin` or click your Sign In button.
+* Authenticate with Discord.
+* Confirm you're redirected back and see a session-aware page (e.g., user info displayed).
+
+### 2. Protected Page Access
+
+* Visit a protected route (e.g., `/protected`) without logging in.
+* Ensure you're redirected to the sign-in page.
+* Log in and revisit `/protected`.
+* Ensure content loads properly and session data is displayed.
+
+### 3. Sign Out Flow
+
+* Click the Sign Out button.
+* Try accessing `/protected` again — confirm redirection back to login.
+
+---
+
+## 🧪 Automated Testing
+
+### Unit Tests (Jest)
+
+* Location: `tests/unit/`
+* Run: `npm run test`
+* Coverage: Test key utilities, session logic, UI components if using React
+
+### API Integration Tests (Supertest)
+
+* Location: `tests/integration/`
+* Focus:
+
+  * `/api/auth` routes
+  * Session persistence middleware
+  * Discord OAuth token handling
+
+#### Sample Test Example (for `/protected`):
+
+```js
+const request = require('supertest');
+const app = require('../../api/index');
+
+describe('GET /protected', () => {
+  it('should redirect if not authenticated', async () => {
+    const res = await request(app).get('/protected');
+    expect(res.status).toBe(302);
+    expect(res.header.location).toContain('/api/auth/signin');
+  });
+});
+```
+
+---
+
+## 🔁 Testing in Dev Workflow
+
+* Run `npm run dev` to start the server with hot reload.
+* Use Discord test account for repeated login/logout.
+* Ensure `.env.local` is correctly set up with Discord credentials.
+* Use browser DevTools to inspect cookies and session tokens.
+
+---
+
+## 🧰 Troubleshooting
+
+* **Issue:** Redirect loop
+
+  * **Fix:** Check `NEXTAUTH_URL` matches your local or prod domain.
+
+* **Issue:** Auth state
+
+
 > Built for the Pyro Freelancer Corps. Stay frosty, don't submit low-effort screenshots, and always back up your bloody database.
 

--- a/public/auth/discord.html
+++ b/public/auth/discord.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Discord Login</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <h1>Login with Discord</h1>
+  <p>Click below to authenticate with Discord.</p>
+  <button onclick="window.location.href='/auth/discord/redirect'">Authorize</button>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,9 @@
 <body>
   <h1>Welcome to the Pyro Freelancer Corps</h1>
   <p>This is a public landing page.</p>
-  <a class="login" href="/auth/discord">Login with Discord</a>
+  <button onclick="window.location.href='/auth/discord'">Login with Discord</button>
+  <br>
+  <a href="/member">Member Page</a>
   <script src="script.js"></script>
 </body>
 </html>

--- a/public/unauthorized.html
+++ b/public/unauthorized.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Unauthorized</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Access Denied</h1>
+  <p>You must log in with Discord to view this page.</p>
+  <a href="/">Return Home</a>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,5 +1,4 @@
 const express = require('express');
-const path = require('path');
 const session = require('express-session');
 const passport = require('passport');
 const DiscordStrategy = require('passport-discord').Strategy;
@@ -48,10 +47,14 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 function checkAuth(req, res, next) {
   if (req.isAuthenticated()) return next();
-  res.redirect('/');
+  res.redirect('/unauthorized.html');
 }
 
-app.get('/auth/discord', passport.authenticate('discord'));
+app.get('/auth/discord', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'auth', 'discord.html'));
+});
+
+app.get('/auth/discord/redirect', passport.authenticate('discord'));
 
 app.get(
   '/auth/discord/callback',
@@ -67,16 +70,9 @@ app.get('/logout', (req, res) => {
   });
 });
 
-// Protect direct access to member.html
-app.get('/member.html', checkAuth, (req, res) => {
-  res.sendFile(path.join(__dirname, 'member.html'));
-});
-
 app.get('/member', checkAuth, (req, res) => {
   res.sendFile(path.join(__dirname, 'protected', 'member.html'));
 });
 
-// Serve static files after protecting member routes
-app.use(express.static(__dirname));
 
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- fix duplicate path import and cleanup server routes
- restrict `/member` route and remove unused direct member file
- add login button and Member Page link on index
- create login page and redirect route for Discord auth

## Testing
- `npm test`
- `DISCORD_CLIENT_ID=1 DISCORD_CLIENT_SECRET=1 node server.js &`
- `curl -I http://localhost:3000/auth/discord`
- `curl -I http://localhost:3000/auth/discord/redirect`


------
https://chatgpt.com/codex/tasks/task_b_684057cf8b4c832d958f5efeb1b89a82