### PR TITLE
Fix index location and auth path

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body>
   <h1>Welcome to the Pyro Freelancer Corps</h1>
   <p>This is a public landing page.</p>
-  <button onclick="window.location.href='/auth/discord'">Login with Discord</button>
+  <button onclick="window.location.href='/auth/discord/redirect'">Login with Discord</button>
   <br>
   <a href="/member">Member Page</a>
   <script src="script.js"></script>

--- a/server.js
+++ b/server.js
@@ -45,6 +45,11 @@ app.use(passport.initialize());
 app.use(passport.session());
 app.use(express.static(path.join(__dirname, 'public')));
 
+// Serve the main index.html from the project root
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'index.html'));
+});
+
 function checkAuth(req, res, next) {
   if (req.isAuthenticated()) return next();
   res.redirect('/unauthorized.html');


### PR DESCRIPTION
## Summary
- move `index.html` to project root
- link to correct Discord auth redirect
- serve root index in Express

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6840622b0ed4832dba476490ed5b890e