### PR TITLE
Add logout button

### DIFF
--- a/html/accolade.html
+++ b/html/accolade.html
@@ -15,6 +15,7 @@
   <nav class="flex justify-end p-4 bg-black space-x-4">
     <a href="../index.html" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded">Home</a>
     <a href="accolades.html" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded">All Accolades</a>
+    <button id="logout-btn" onclick="PFCDiscord.logout()" class="bg-gray-600 hover:bg-gray-800 text-white font-bold py-2 px-4 rounded hidden">Logout</button>
   </nav>
 
   <section class="py-16 px-6 text-center max-w-4xl mx-auto">
@@ -28,6 +29,13 @@
   </footer>
 
   <img src="../images/Fankit/03_LOGOS/MadeByTheCommunity_Black.png" alt="Made by the Community" class="community-watermark">
+  <script>
+    window.addEventListener('DOMContentLoaded', () => {
+      if (localStorage.getItem('jwt')) {
+        document.getElementById('logout-btn')?.classList.remove('hidden');
+      }
+    });
+  </script>
 
-</body>
-</html>
+  </body>
+  </html>

--- a/html/accolades.html
+++ b/html/accolades.html
@@ -14,6 +14,7 @@
 <body class="bg-black text-white">
   <nav class="flex justify-end p-4 bg-black space-x-4">
     <a href="../index.html" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded">Home</a>
+    <button id="logout-btn" onclick="PFCDiscord.logout()" class="bg-gray-600 hover:bg-gray-800 text-white font-bold py-2 px-4 rounded hidden">Logout</button>
   </nav>
 
   <section class="py-16 px-6 text-center">
@@ -27,6 +28,13 @@
   </footer>
 
   <img src="../images/Fankit/03_LOGOS/MadeByTheCommunity_Black.png" alt="Made by the Community" class="community-watermark">
+  <script>
+    window.addEventListener('DOMContentLoaded', () => {
+      if (localStorage.getItem('jwt')) {
+        document.getElementById('logout-btn')?.classList.remove('hidden');
+      }
+    });
+  </script>
 
-</body>
-</html>
+  </body>
+  </html>

--- a/html/events.html
+++ b/html/events.html
@@ -14,6 +14,7 @@
 <body class="bg-black text-white">
   <nav class="flex justify-end p-4 bg-black space-x-4">
     <a href="../index.html" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded">Home</a>
+    <button id="logout-btn" onclick="PFCDiscord.logout()" class="bg-gray-600 hover:bg-gray-800 text-white font-bold py-2 px-4 rounded hidden">Logout</button>
   </nav>
 
   <section class="py-16 px-6 text-center">
@@ -26,6 +27,13 @@
   </footer>
 
   <img src="../images/Fankit/03_LOGOS/MadeByTheCommunity_Black.png" alt="Made by the Community" class="community-watermark">
+  <script>
+    window.addEventListener('DOMContentLoaded', () => {
+      if (localStorage.getItem('jwt')) {
+        document.getElementById('logout-btn')?.classList.remove('hidden');
+      }
+    });
+  </script>
 
-</body>
-</html>
+  </body>
+  </html>

--- a/index.html
+++ b/index.html
@@ -58,7 +58,8 @@
   <section class="py-10 px-6 text-center">
     <h2 class="text-3xl font-bold mb-4 text-pfc-red">Login</h2>
     <p class="mb-6 text-lg text-gray-300">Authenticate using your Discord account:</p>
-    <button onclick="PFCDiscord.startDiscordLogin()" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-6 rounded">Login with Discord</button>
+    <button id="login-btn" onclick="PFCDiscord.startDiscordLogin()" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-6 rounded">Login with Discord</button>
+    <button id="logout-btn" onclick="PFCDiscord.logout()" class="bg-gray-600 hover:bg-gray-800 text-white font-bold py-2 px-6 rounded hidden mt-2">Logout</button>
     <div id="dashboard-link" class="hidden mt-4">
       <a href="html/events.html" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-6 rounded inline-block">Go to Dashboard</a>
     </div>
@@ -78,9 +79,14 @@
   
       const token = localStorage.getItem('jwt');
       console.log("JWT in storage:", token);
-  
+
       if (token) {
         document.getElementById('dashboard-link')?.classList.remove('hidden');
+        document.getElementById('logout-btn')?.classList.remove('hidden');
+        document.getElementById('login-btn')?.classList.add('hidden');
+      } else {
+        document.getElementById('logout-btn')?.classList.add('hidden');
+        document.getElementById('login-btn')?.classList.remove('hidden');
       }
     });
   </script>

--- a/js/auth.js
+++ b/js/auth.js
@@ -50,5 +50,11 @@ window.PFCDiscord = {
     } catch (err) {
       console.error('🔥 Auth error:', err);
     }
+  },
+
+  logout() {
+    localStorage.removeItem('jwt');
+    console.log('🔒 Logged out and removed JWT');
+    window.location.reload();
   }
 };


### PR DESCRIPTION
## Summary
- add logout method to auth
- show logout button on index after login
- include logout button/nav on events and accolades pages
- render logout button on accolade page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845a08ad678832d9992b6d08a20c2d6