### PR TITLE
Fix accolades auth

### DIFF
--- a/js/accolade.js
+++ b/js/accolade.js
@@ -18,7 +18,9 @@ async function loadAccoladePage() {
   }
 
   try {
-    const res = await fetch(`${window.PFC_CONFIG.apiBase}/api/accolades`);
+    const token = localStorage.getItem('jwt');
+    const headers = token ? { 'Authorization': `Bearer ${token}` } : {};
+    const res = await fetch(`${window.PFC_CONFIG.apiBase}/api/accolades`, { headers });
 
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const { accolades } = await res.json();

--- a/js/accolades.js
+++ b/js/accolades.js
@@ -3,7 +3,9 @@
 async function loadAccolades() {
   const container = document.getElementById('accolade-list');
   try {
-    const res = await fetch(`${window.PFC_CONFIG.apiBase}/api/accolades`);
+    const token = localStorage.getItem('jwt');
+    const headers = token ? { 'Authorization': `Bearer ${token}` } : {};
+    const res = await fetch(`${window.PFC_CONFIG.apiBase}/api/accolades`, { headers });
 
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const { accolades } = await res.json();


### PR DESCRIPTION
## Summary
- attach Authorization header when loading the accolades list
- secure single accolade page with JWT

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845a4ec54d0832d9f9390fbdb4f6035