### PR TITLE
Show logged in Discord user

### DIFF
--- a/html/accolade.html
+++ b/html/accolade.html
@@ -12,9 +12,10 @@
   <script src="../js/accolade.js" defer></script>
 </head>
 <body class="bg-black text-white">
-  <nav class="flex justify-end p-4 bg-black space-x-4">
+  <nav class="flex justify-end items-center p-4 bg-black space-x-4">
     <a href="../index.html" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded">Home</a>
     <a href="accolades.html" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded">All Accolades</a>
+    <span id="display-name" class="text-gray-300 hidden"></span>
     <button id="logout-btn" onclick="PFCDiscord.logout()" class="bg-gray-600 hover:bg-gray-800 text-white font-bold py-2 px-4 rounded hidden">Logout</button>
   </nav>
 
@@ -31,8 +32,15 @@
   <img src="../images/Fankit/03_LOGOS/MadeByTheCommunity_Black.png" alt="Made by the Community" class="community-watermark">
   <script>
     window.addEventListener('DOMContentLoaded', () => {
-      if (localStorage.getItem('jwt')) {
+      const token = localStorage.getItem('jwt');
+      if (token) {
         document.getElementById('logout-btn')?.classList.remove('hidden');
+        const user = PFCDiscord.getUser();
+        if (user && user.displayName) {
+          const nameEl = document.getElementById('display-name');
+          nameEl.textContent = user.displayName;
+          nameEl.classList.remove('hidden');
+        }
       }
     });
   </script>

--- a/html/accolades.html
+++ b/html/accolades.html
@@ -12,8 +12,9 @@
   <script src="../js/accolades.js" defer></script>
 </head>
 <body class="bg-black text-white">
-  <nav class="flex justify-end p-4 bg-black space-x-4">
+  <nav class="flex justify-end items-center p-4 bg-black space-x-4">
     <a href="../index.html" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded">Home</a>
+    <span id="display-name" class="text-gray-300 hidden"></span>
     <button id="logout-btn" onclick="PFCDiscord.logout()" class="bg-gray-600 hover:bg-gray-800 text-white font-bold py-2 px-4 rounded hidden">Logout</button>
   </nav>
 
@@ -30,8 +31,15 @@
   <img src="../images/Fankit/03_LOGOS/MadeByTheCommunity_Black.png" alt="Made by the Community" class="community-watermark">
   <script>
     window.addEventListener('DOMContentLoaded', () => {
-      if (localStorage.getItem('jwt')) {
+      const token = localStorage.getItem('jwt');
+      if (token) {
         document.getElementById('logout-btn')?.classList.remove('hidden');
+        const user = PFCDiscord.getUser();
+        if (user && user.displayName) {
+          const nameEl = document.getElementById('display-name');
+          nameEl.textContent = user.displayName;
+          nameEl.classList.remove('hidden');
+        }
       }
     });
   </script>

--- a/html/events.html
+++ b/html/events.html
@@ -12,8 +12,9 @@
   <script src="../js/events.js" defer></script>
 </head>
 <body class="bg-black text-white">
-  <nav class="flex justify-end p-4 bg-black space-x-4">
+  <nav class="flex justify-end items-center p-4 bg-black space-x-4">
     <a href="../index.html" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded">Home</a>
+    <span id="display-name" class="text-gray-300 hidden"></span>
     <button id="logout-btn" onclick="PFCDiscord.logout()" class="bg-gray-800 hover:bg-gray-800 text-white font-bold py-2 px-4 rounded hidden">Logout</button>
   </nav>
 
@@ -29,8 +30,15 @@
   <img src="../images/Fankit/03_LOGOS/MadeByTheCommunity_Black.png" alt="Made by the Community" class="community-watermark">
   <script>
     window.addEventListener('DOMContentLoaded', () => {
-      if (localStorage.getItem('jwt')) {
+      const token = localStorage.getItem('jwt');
+      if (token) {
         document.getElementById('logout-btn')?.classList.remove('hidden');
+        const user = PFCDiscord.getUser();
+        if (user && user.displayName) {
+          const nameEl = document.getElementById('display-name');
+          nameEl.textContent = user.displayName;
+          nameEl.classList.remove('hidden');
+        }
       }
     });
   </script>

--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
     <p class="mb-6 text-lg text-gray-300">Authenticate using your Discord account:</p>
     <button id="login-btn" onclick="PFCDiscord.startDiscordLogin()" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-6 rounded">Login with Discord</button>
     <button id="logout-btn" onclick="PFCDiscord.logout()" class="bg-gray-600 hover:bg-gray-800 text-white font-bold py-2 px-6 rounded hidden mt-2">Logout</button>
+    <p id="user-info" class="text-gray-300 mt-2 hidden">Logged in as <span id="display-name"></span></p>
     <div id="dashboard-link" class="hidden mt-4">
       <a href="html/events.html" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-6 rounded inline-block">Go to Dashboard</a>
     </div>
@@ -84,9 +85,17 @@
         document.getElementById('dashboard-link')?.classList.remove('hidden');
         document.getElementById('logout-btn')?.classList.remove('hidden');
         document.getElementById('login-btn')?.classList.add('hidden');
+        const user = PFCDiscord.getUser();
+        if (user && user.displayName) {
+          const info = document.getElementById('user-info');
+          const nameEl = document.getElementById('display-name');
+          nameEl.textContent = user.displayName;
+          info.classList.remove('hidden');
+        }
       } else {
         document.getElementById('logout-btn')?.classList.add('hidden');
         document.getElementById('login-btn')?.classList.remove('hidden');
+        document.getElementById('user-info')?.classList.add('hidden');
       }
     });
   </script>

--- a/js/auth.js
+++ b/js/auth.js
@@ -56,5 +56,24 @@ window.PFCDiscord = {
     localStorage.removeItem('jwt');
     console.log('🔒 Logged out and removed JWT');
     window.location.reload();
+  },
+
+  /**
+   * Decode the JWT payload stored in localStorage.
+   * @returns {object|null}
+   */
+  getUser() {
+    const token = localStorage.getItem('jwt');
+    if (!token) return null;
+    try {
+      const base64 = token.split('.')[1]
+        .replace(/-/g, '+')
+        .replace(/_/g, '/');
+      const json = atob(base64);
+      return JSON.parse(json);
+    } catch (err) {
+      console.error('Failed to decode JWT', err);
+      return null;
+    }
   }
 };


### PR DESCRIPTION
## Summary
- decode JWT payload to access logged in user info
- display Discord display name on the main page
- show display name in nav bars for events and accolades pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845a51b9054832d9f7a7068db7ece86