### PR TITLE
Add admin console with log search

### DIFF
--- a/html/admin.html
+++ b/html/admin.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Admin Console - Pyro Freelancer Corps</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="../css/main.css">
+  <script src="../js/config.js"></script>
+  <script src="../js/utils.js"></script>
+  <script src="../js/auth.js" defer></script>
+  <script src="../js/admin.js" defer></script>
+</head>
+<body class="bg-black text-white">
+  <nav class="flex justify-end items-center p-4 bg-black space-x-4">
+    <a href="../index.html" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded">Home</a>
+    <span id="display-name" class="text-gray-300 hidden"></span>
+    <button id="logout-btn" onclick="PFCDiscord.logout()" class="bg-gray-600 hover:bg-gray-800 text-white font-bold py-2 px-4 rounded hidden">Logout</button>
+  </nav>
+
+  <section class="py-16 px-6 text-center">
+    <h1 class="text-4xl font-bold text-pfc-red mb-8">Admin Console</h1>
+    <a href="log-search.html" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded">Search Logs</a>
+  </section>
+
+  <footer class="bg-black text-gray-400 py-6 text-center">
+    <p>&copy; 2025 Pyro Freelancer Corps. All rights reserved.</p>
+  </footer>
+
+  <img src="../images/Fankit/03_LOGOS/MadeByTheCommunity_Black.png" alt="Made by the Community" class="community-watermark">
+</body>
+</html>

--- a/html/log-search.html
+++ b/html/log-search.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Activity Log Search - PFC</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="../css/main.css">
+  <script src="../js/config.js"></script>
+  <script src="../js/utils.js"></script>
+  <script src="../js/auth.js" defer></script>
+  <script src="../js/logSearch.js" defer></script>
+</head>
+<body class="bg-black text-white">
+  <nav class="flex justify-end items-center p-4 bg-black space-x-4">
+    <a href="admin.html" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded">Admin Home</a>
+    <span id="display-name" class="text-gray-300 hidden"></span>
+    <button id="logout-btn" onclick="PFCDiscord.logout()" class="bg-gray-600 hover:bg-gray-800 text-white font-bold py-2 px-4 rounded hidden">Logout</button>
+  </nav>
+
+  <section class="py-8 px-6">
+    <h1 class="text-3xl font-bold text-pfc-red mb-4 text-center">Activity Log Search</h1>
+    <form id="log-search-form" class="space-y-4 mb-6 text-black">
+      <div>
+        <label class="block text-white mb-1" for="type">Type</label>
+        <select id="type" class="w-full p-2 rounded"></select>
+      </div>
+      <div>
+        <label class="block text-white mb-1" for="userId">User</label>
+        <select id="userId" class="w-full p-2 rounded"></select>
+      </div>
+      <div>
+        <label class="block text-white mb-1" for="command">Command</label>
+        <select id="command" class="w-full p-2 rounded"></select>
+      </div>
+      <div>
+        <label class="block text-white mb-1" for="message">Message Contains</label>
+        <input id="message" type="text" class="w-full p-2 rounded" />
+      </div>
+      <button type="submit" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded">Search</button>
+    </form>
+
+    <div id="results" class="space-y-4"></div>
+  </section>
+
+  <footer class="bg-black text-gray-400 py-6 text-center">
+    <p>&copy; 2025 Pyro Freelancer Corps. All rights reserved.</p>
+  </footer>
+
+  <img src="../images/Fankit/03_LOGOS/MadeByTheCommunity_Black.png" alt="Made by the Community" class="community-watermark">
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     <p id="user-info" class="text-gray-300 mt-2 hidden">Logged in as <span id="display-name"></span></p>
     <a href="html/events.html" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded">Events</a>
     <a href="html/accolades.html" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded">Accolades</a>
+    <a href="html/admin.html" id="admin-link" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded hidden">Admin</a>
     <button id="login-btn" onclick="PFCDiscord.startDiscordLogin()" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-6 rounded">Login with Discord</button>
     <button id="logout-btn" onclick="PFCDiscord.logout()" class="bg-gray-800 hover:bg-gray-800 text-white font-bold py-2 px-6 rounded">Logout</button>
   </nav>
@@ -77,17 +78,25 @@
         document.getElementById('logout-btn')?.classList.remove('hidden');
         document.getElementById('login-btn')?.classList.add('hidden');
         const user = PFCDiscord.getUser();
-        
+
         if (user) {
           const info = document.getElementById('user-info');
           const nameEl = document.getElementById('display-name');
           nameEl.textContent = user.displayName;
           info.classList.remove('hidden');
+
+          const adminLink = document.getElementById('admin-link');
+          if (Array.isArray(user.roles) && user.roles.includes('Server Admin')) {
+            adminLink?.classList.remove('hidden');
+          } else {
+            adminLink?.classList.add('hidden');
+          }
         }
       } else {
         document.getElementById('logout-btn')?.classList.add('hidden');
         document.getElementById('login-btn')?.classList.remove('hidden');
         document.getElementById('user-info')?.classList.add('hidden');
+        document.getElementById('admin-link')?.classList.add('hidden');
       }
     });
   </script>

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,0 +1,17 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const token = localStorage.getItem('jwt');
+  const user = PFCDiscord.getUser();
+  const isAdmin = Array.isArray(user?.roles) && user.roles.includes('Server Admin');
+
+  if (!token || !isAdmin) {
+    window.location.href = '../index.html';
+    return;
+  }
+
+  document.getElementById('logout-btn')?.classList.remove('hidden');
+  const nameEl = document.getElementById('display-name');
+  if (nameEl) {
+    nameEl.textContent = user.displayName;
+    nameEl.classList.remove('hidden');
+  }
+});

--- a/js/logSearch.js
+++ b/js/logSearch.js
@@ -1,0 +1,93 @@
+async function populateFilters() {
+  const token = localStorage.getItem('jwt');
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+
+  try {
+    const [commandsRes, membersRes] = await Promise.all([
+      fetch(`${window.PFC_CONFIG.apiBase}/api/commands`, { headers }),
+      fetch(`${window.PFC_CONFIG.apiBase}/api/members`, { headers })
+    ]);
+
+    const commands = commandsRes.ok ? await commandsRes.json() : [];
+    const members = membersRes.ok ? await membersRes.json() : [];
+
+    const commandSelect = document.getElementById('command');
+    commandSelect.innerHTML = '<option value="">Any</option>' +
+      commands.map(c => `<option value="${c}">${c}</option>`).join('');
+
+    const userSelect = document.getElementById('userId');
+    userSelect.innerHTML = '<option value="">Any</option>' +
+      members.map(m => `<option value="${m.userId}">${m.username}</option>`).join('');
+
+    const typeSelect = document.getElementById('type');
+    typeSelect.innerHTML = '<option value="">Any</option>' +
+      ['LOGIN','COMMAND_EXECUTION'].map(t => `<option value="${t}">${t}</option>`).join('');
+  } catch (err) {
+    console.error('Failed to populate filters', err);
+  }
+}
+
+function renderResults(logs = []) {
+  const container = document.getElementById('results');
+  if (!Array.isArray(logs) || logs.length === 0) {
+    container.innerHTML = '<p class="text-gray-300">No results found.</p>';
+    return;
+  }
+
+  container.innerHTML = logs.map(log => `
+    <div class="card">
+      <h3>${log.type} - ${log.userId}</h3>
+      <p class="text-sm">${log.timestamp || ''}</p>
+      <p>${log.command || ''}</p>
+      <p>${log.message || ''}</p>
+    </div>
+  `).join('');
+}
+
+async function searchLogs(e) {
+  e.preventDefault();
+  const token = localStorage.getItem('jwt');
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+
+  const params = new URLSearchParams();
+  const type = document.getElementById('type').value;
+  const userId = document.getElementById('userId').value;
+  const command = document.getElementById('command').value;
+  const message = document.getElementById('message').value;
+
+  if (type) params.set('type', type);
+  if (userId) params.set('userId', userId);
+  if (command) params.set('command', command);
+  if (message) params.set('message', message);
+
+  const url = `${window.PFC_CONFIG.apiBase}/api/activity-log/search?${params.toString()}`;
+  try {
+    const res = await fetch(url, { headers });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    renderResults(data.logs || data.results || []);
+  } catch (err) {
+    console.error('Search failed', err);
+  }
+}
+
+window.addEventListener('DOMContentLoaded', async () => {
+  const user = PFCDiscord.getUser();
+  const token = localStorage.getItem('jwt');
+  const isAdmin = Array.isArray(user?.roles) && user.roles.includes('Server Admin');
+
+  if (!token || !isAdmin) {
+    window.location.href = '../index.html';
+    return;
+  }
+
+  document.getElementById('logout-btn')?.classList.remove('hidden');
+  const nameEl = document.getElementById('display-name');
+  if (nameEl) {
+    nameEl.textContent = user.displayName;
+    nameEl.classList.remove('hidden');
+  }
+
+  await populateFilters();
+  document.getElementById('log-search-form').addEventListener('submit', searchLogs);
+});


### PR DESCRIPTION
## Summary
- link to the admin console appears for Server Admins
- create Admin Console page
- create activity log search form for admins
- basic JS to gate pages based on presence of `Server Admin` role
- tighten gating redirects for admin pages

## Testing
- `npm test` *(fails: `npm` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6845bc8c85bc832db06c0f77443944e5