### PR TITLE
Improve log search filters

### DIFF
--- a/html/log-search.html
+++ b/html/log-search.html
@@ -27,12 +27,15 @@
         <select id="type" class="w-full p-2 rounded"></select>
       </div>
       <div>
-        <label class="block text-white mb-1" for="userId">User</label>
-        <select id="userId" class="w-full p-2 rounded"></select>
+        <label class="block text-white mb-1" for="user-search">User</label>
+        <input id="user-search" list="user-options" class="w-full p-2 rounded" autocomplete="off">
+        <datalist id="user-options"></datalist>
+        <input type="hidden" id="userId" />
       </div>
       <div>
         <label class="block text-white mb-1" for="command">Command</label>
-        <select id="command" class="w-full p-2 rounded"></select>
+        <input id="command" list="command-options" class="w-full p-2 rounded" autocomplete="off">
+        <datalist id="command-options"></datalist>
       </div>
       <div>
         <label class="block text-white mb-1" for="message">Message Contains</label>

--- a/js/logSearch.js
+++ b/js/logSearch.js
@@ -1,23 +1,55 @@
+let allCommands = [];
+let allMembers = [];
+let usernameToId = {};
+
+function fuzzyMatch(str, pattern) {
+  pattern = pattern.toLowerCase();
+  str = str.toLowerCase();
+  let i = 0;
+  for (const ch of pattern) {
+    i = str.indexOf(ch, i);
+    if (i === -1) return false;
+    i++;
+  }
+  return true;
+}
+
+function updateUserDatalist(term = '') {
+  const list = document.getElementById('user-options');
+  list.innerHTML = allMembers
+    .filter(m => fuzzyMatch(m.username, term))
+    .slice(0, 25)
+    .map(m => `<option value="${m.username}">`)
+    .join('');
+}
+
+function updateCommandDatalist(term = '') {
+  const list = document.getElementById('command-options');
+  list.innerHTML = allCommands
+    .filter(c => fuzzyMatch(c, term))
+    .slice(0, 25)
+    .map(c => `<option value="${c}">`)
+    .join('');
+}
+
 async function populateFilters() {
   const token = localStorage.getItem('jwt');
   const headers = token ? { Authorization: `Bearer ${token}` } : {};
 
   try {
     const [commandsRes, membersRes] = await Promise.all([
-      fetch(`${window.PFC_CONFIG.apiBase}/api/commands`, { headers }),
+      fetch(`${window.PFC_CONFIG.apiBase}/api/activity-log/commands`, { headers }),
       fetch(`${window.PFC_CONFIG.apiBase}/api/members`, { headers })
     ]);
 
-    const commands = commandsRes.ok ? await commandsRes.json() : [];
-    const members = membersRes.ok ? await membersRes.json() : [];
+    allCommands = commandsRes.ok ? await commandsRes.json() : [];
+    allMembers = membersRes.ok ? await membersRes.json() : [];
 
-    const commandSelect = document.getElementById('command');
-    commandSelect.innerHTML = '<option value="">Any</option>' +
-      commands.map(c => `<option value="${c}">${c}</option>`).join('');
+    usernameToId = {};
+    allMembers.forEach(m => { usernameToId[m.username] = m.userId; });
 
-    const userSelect = document.getElementById('userId');
-    userSelect.innerHTML = '<option value="">Any</option>' +
-      members.map(m => `<option value="${m.userId}">${m.username}</option>`).join('');
+    updateCommandDatalist('');
+    updateUserDatalist('');
 
     const typeSelect = document.getElementById('type');
     typeSelect.innerHTML = '<option value="">Any</option>' +
@@ -89,5 +121,21 @@ window.addEventListener('DOMContentLoaded', async () => {
   }
 
   await populateFilters();
+  const userInput = document.getElementById('user-search');
+  const userHidden = document.getElementById('userId');
+  const commandInput = document.getElementById('command');
+
+  userInput.addEventListener('input', () => {
+    updateUserDatalist(userInput.value);
+    userHidden.value = usernameToId[userInput.value] || '';
+  });
+  userInput.addEventListener('change', () => {
+    userHidden.value = usernameToId[userInput.value] || '';
+  });
+
+  commandInput.addEventListener('input', () => {
+    updateCommandDatalist(commandInput.value);
+  });
+
   document.getElementById('log-search-form').addEventListener('submit', searchLogs);
 });


### PR DESCRIPTION
## Summary
- implement fuzzy dropdowns for commands and members on log search page
- update log filter API endpoints
- add JS for datalist updates and fuzzy matching

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845d88ab204832d9857b175d6097249