### PR TITLE
Fix OAuth login request

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -13,7 +13,10 @@ function finishDiscordLogin() {
   fetch(`${window.PFC_CONFIG.apiBase}/api/login`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ code })
+    body: JSON.stringify({
+      code,
+      redirectUri: window.PFC_CONFIG.redirectUri
+    })
   })
     .then(response => {
       console.log('Received response:', response);


### PR DESCRIPTION
## Summary
- include redirectUri in login POST body so the API can validate the request

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68471c3f8a34832d933c3d7fc85dffa4