### PR TITLE
Remove unused imports

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2,8 +2,7 @@ import './style.css'
 import { runIncludes } from './includes.js'
 import * as nav from './nav.js'
 import * as router from './router.js'
-import {finishDiscordLogin, startDiscordLogin, logout, getUser} from './auth.js'
-import { slugify } from './utils.js'
+import { finishDiscordLogin } from './auth.js'
 
 // Log boot
 console.log('[MAIN] Booting up...')


### PR DESCRIPTION
## Summary
- remove unused `slugify` line and extra auth helpers in main.js

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_b_684eddbeba2c832d9fa5b327bdcdf27d