### PR TITLE
Refactor login and includes to async/await

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -1,6 +1,6 @@
 import { PFC_CONFIG } from "./config";
 
-function finishDiscordLogin() {
+async function finishDiscordLogin() {
   console.log('finishDiscordLogin triggered.');
 
   const params = new URLSearchParams(window.location.search);
@@ -12,31 +12,30 @@ function finishDiscordLogin() {
     return;
   }
 
-  fetch(`${PFC_CONFIG.apiBase}/api/login`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      code,
-      redirectUri: PFC_CONFIG.redirectUri
-    })
-  })
-    .then(response => {
-      console.log('Received response:', response);
-      return response.json();
-    })
-    .then(data => {
-      console.log('Parsed response JSON:', data);
-      if (data && data.token) {
-        localStorage.setItem('jwt', data.token);
-        console.log('✅ JWT stored:', data.token);
-      } else {
-        console.warn('[auth] No token received from API:', data);
-      }
-      window.location.href = PFC_CONFIG.redirectUri;
-    })
-    .catch(err => {
-      console.error('❌ Error finishing Discord login:', err);
+  try {
+    const response = await fetch(`${PFC_CONFIG.apiBase}/api/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        code,
+        redirectUri: PFC_CONFIG.redirectUri
+      })
     });
+    console.log('Received response:', response);
+    const data = await response.json();
+    console.log('Parsed response JSON:', data);
+    if (data && data.token) {
+      localStorage.setItem('jwt', data.token);
+      console.log('✅ JWT stored:', data.token);
+    } else {
+      console.warn('[auth] No token received from API:', data);
+    }
+    window.location.href = PFC_CONFIG.redirectUri;
+    return data;
+  } catch (err) {
+    console.error('❌ Error finishing Discord login:', err);
+    return null;
+  }
 }
 
 function getUser() {

--- a/src/includes.js
+++ b/src/includes.js
@@ -1,24 +1,22 @@
 // src/includes.js
 
-export function runIncludes() {
+export async function runIncludes() {
   const includeElements = document.querySelectorAll('[data-include]')
-  includeElements.forEach(el => {
+  const tasks = Array.from(includeElements).map(async el => {
     const file = el.getAttribute('data-include')
     if (!file) return
 
-    fetch(file)
-      .then(res => {
-        if (!res.ok) throw new Error(`Failed to fetch ${file}`)
-        return res.text()
-      })
-      .then(content => {
-        el.innerHTML = content
-        if (file.includes('nav.html')) {
-          document.dispatchEvent(new Event('nav-ready'))
-        }
-      })
-      .catch(err => {
-        console.error(`[includes.js] Error loading ${file}:`, err)
-      })
+    try {
+      const res = await fetch(file)
+      if (!res.ok) throw new Error(`Failed to fetch ${file}`)
+      const content = await res.text()
+      el.innerHTML = content
+      if (file.includes('nav.html')) {
+        document.dispatchEvent(new Event('nav-ready'))
+      }
+    } catch (err) {
+      console.error(`[includes.js] Error loading ${file}:`, err)
+    }
   })
+  return Promise.all(tasks)
 }


### PR DESCRIPTION
## Summary
- refactor OAuth login helper to async/await with proper return values
- convert include loader to async/await

## Testing
- `npm run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_b_684eddc647a4832dabf7688e8cd58a55