### PR TITLE
Fix navigation error in unauthorized view

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -13,7 +13,7 @@ const routes = {
   '/product/:handle': 'views/shop.html'
 };
 
-function navigateTo(url) {
+export function navigateTo(url) {
   history.pushState(null, null, url);
   loadRoute();
 }

--- a/src/unauthorized.js
+++ b/src/unauthorized.js
@@ -1,12 +1,13 @@
+import { navigateTo } from './router.js';
+
 export async function init() {
-    console.log('[unauthorized.js] Init called');
-  
-    // Optional: Add any interactive behaviour here
-    const homeBtn = document.querySelector('a[data-link]');
-    homeBtn?.addEventListener('click', e => {
-      e.preventDefault();
-      history.pushState(null, null, '/');
-      loadInitialRoute(); // Should already exist in your SPA setup
-    });
-  }
+  console.log('[unauthorized.js] Init called');
+
+  // Optional: Add any interactive behaviour here
+  const homeBtn = document.querySelector('a[data-link]');
+  homeBtn?.addEventListener('click', e => {
+    e.preventDefault();
+    navigateTo('/');
+  });
+}
   


### PR DESCRIPTION
## Summary
- export `navigateTo` from router
- use router's API in `unauthorized.js` to navigate home

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_b_684eddd81078832daa5dd2ff6cf9e094