### PR TITLE
Use env vars for Shopify API constants

### DIFF
--- a/src/api/shopify.js
+++ b/src/api/shopify.js
@@ -1,8 +1,16 @@
 // src/api/shopify.js
 
-const SHOPIFY_DOMAIN = 'pfc-commissary.myshopify.com'; // Replace with actual domain
-const STOREFRONT_TOKEN = '33522d6190a58189d30ed85f4c48549f'; // Replace with actual token
+// Shopify store domain, e.g. "example.myshopify.com"
+const SHOPIFY_DOMAIN = import.meta.env.VITE_SHOPIFY_DOMAIN;
+// Storefront access token generated from the Shopify admin
+const STOREFRONT_TOKEN = import.meta.env.VITE_SHOPIFY_STOREFRONT_TOKEN;
 
+/**
+ * Execute a GraphQL query against the Shopify Storefront API.
+ * @param {string} query - GraphQL query string
+ * @param {Object} variables - optional variables for the query
+ * @returns {Promise<Object>} resolved data from the API
+ */
 export async function shopifyGraphQL(query, variables = {}) {
   const response = await fetch(`https://${SHOPIFY_DOMAIN}/api/2023-04/graphql.json`, {
     method: 'POST',
@@ -80,6 +88,11 @@ export const GET_PRODUCT_QUERY = `
   }
 `;
 
+/**
+ * Generate a mutation to create a checkout for a given variant ID.
+ * @param {string} variantId - Shopify variant identifier
+ * @returns {string} GraphQL mutation string
+ */
 export function getCreateCheckoutMutation(variantId) {
   return `
     mutation {
@@ -97,3 +110,4 @@ export function getCreateCheckoutMutation(variantId) {
     }
   `;
 }
+

--- a/src/config.example.js
+++ b/src/config.example.js
@@ -1,3 +1,11 @@
+// Example configuration file.
+// Copy to `src/config.js` or use Vite environment variables.
+// Required env vars:
+//   VITE_API_BASE - base URL for the external API
+//   VITE_REDIRECT_URI - OAuth redirect URL of this site
+//   VITE_DISCORD_CLIENT_ID - Discord OAuth client ID
+//   VITE_SHOPIFY_DOMAIN - Shopify store domain (e.g. "example.myshopify.com")
+//   VITE_SHOPIFY_STOREFRONT_TOKEN - Shopify storefront API token
 window.PFC_CONFIG = {
   apiBase: "https://api.example.com",
   redirectUri: "https://yourdomain.com/index.html",


### PR DESCRIPTION
## Summary
- load Shopify domain and storefront token from `import.meta.env`
- document all required env vars in `config.example.js`

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_b_684edde20e84832db11153299e12364d