### PR TITLE
Remove unused CSS selectors

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -12,13 +12,6 @@
     color: var(--pfc-red);
   }
   
-  .text-pfc-gold {
-    color: var(--pfc-gold);
-  }
-  
-  .bg-pfc-gold {
-    background-color: var(--pfc-gold);
-  }
   
   .card {
     background-color: #111;
@@ -67,25 +60,7 @@
     margin-bottom: 0.5rem;
   }
 
-  .community-watermark {
-    position: fixed;
-    bottom: 1rem;
-    left: 1rem;
-    width: 100px; /* Adjust as needed */
-    opacity: 0.2; /* Light touch for watermark effect */
-    z-index: 10;
-    pointer-events: none; /* So it doesn't interfere with clicks */
-  }
 
-  #nav-menu {
-    max-height: 0;
-    overflow: hidden;
-    transition: max-height 0.3s ease;
-  }
-  
-  #nav-menu.expanded {
-    max-height: 500px; /* Enough room for all menu items */
-  }
 
   .product-grid {
     display: grid;
@@ -131,11 +106,6 @@
     background-color: var(--pfc-gold);
   }
 
-  .shop-header {
-    text-align: center;
-    margin-bottom: 2rem;
-  }
-  
   .shop-header h1 {
     font-size: 2.25rem;
     margin-bottom: 0.25rem;
@@ -206,17 +176,9 @@
     align-items: center;
     justify-content: center;
     padding-bottom: 1rem;
+    text-align: center;
+    margin-bottom: 2rem;
   }
-  .shop-logo {
-    max-height: 60px;
-  }
-  
-  #filter-tags {
-    display: flex;
-    justify-content: center;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    margin-bottom: 1rem;
-  }
+
   
   


### PR DESCRIPTION
## Summary
- clean up `src/style.css` by removing dead rules
- merge `.shop-header` styling into one block

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_b_684edde7a0c4832dbac0f8788b575c6d