### PR TITLE
Guard debug logs with config flag

### DIFF
--- a/src/accolade.js
+++ b/src/accolade.js
@@ -1,4 +1,6 @@
 import { PFC_CONFIG } from './config.js'
+
+const DEBUG = PFC_CONFIG.debug;
 import { slugify } from './utils.js'
 
 function getSlug() {
@@ -26,7 +28,7 @@ async function loadAccoladePage() {
     const { accolades } = await res.json();
 
     const debugSlugs = accolades.map(a => ({ name: a.name, slug: slugify(a.name) }));
-    console.log('[DEBUG] Available slugs:', debugSlugs);
+    if (DEBUG) console.log('[DEBUG] Available slugs:', debugSlugs);
 
     const accolade = accolades.find(a => slugify(a.name) === slug);
     if (!accolade) throw new Error(`No accolade found matching slug: ${slug}`);

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,14 +1,16 @@
 import { PFC_CONFIG } from "./config";
 
+const DEBUG = PFC_CONFIG.debug;
+
 function finishDiscordLogin() {
-  console.log('finishDiscordLogin triggered.');
+  if (DEBUG) console.log('finishDiscordLogin triggered.');
 
   const params = new URLSearchParams(window.location.search);
   const code = params.get('code');
-  console.log('Parsed code from URL:', code);
+  if (DEBUG) console.log('Parsed code from URL:', code);
 
   if (!code) {
-    console.log('No code found in URL — skipping login finish.');
+    if (DEBUG) console.log('No code found in URL — skipping login finish.');
     return;
   }
 
@@ -21,14 +23,14 @@ function finishDiscordLogin() {
     })
   })
     .then(response => {
-      console.log('Received response:', response);
+      if (DEBUG) console.log('Received response:', response);
       return response.json();
     })
     .then(data => {
-      console.log('Parsed response JSON:', data);
+      if (DEBUG) console.log('Parsed response JSON:', data);
       if (data && data.token) {
         localStorage.setItem('jwt', data.token);
-        console.log('✅ JWT stored:', data.token);
+        if (DEBUG) console.log('✅ JWT stored:', data.token);
       } else {
         console.warn('[auth] No token received from API:', data);
       }
@@ -67,7 +69,7 @@ function startDiscordLogin() {
 
 function logout() {
   localStorage.removeItem('jwt');
-  console.log('🔒 Logged out. Reloading...');
+  if (DEBUG) console.log('🔒 Logged out. Reloading...');
   window.location.reload();
 }
 

--- a/src/config.example.js
+++ b/src/config.example.js
@@ -1,5 +1,6 @@
 window.PFC_CONFIG = {
   apiBase: "https://api.example.com",
   redirectUri: "https://yourdomain.com/index.html",
-  discordClientId: "YOUR_DISCORD_CLIENT_ID"
+  discordClientId: "YOUR_DISCORD_CLIENT_ID",
+  debug: false
 };

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,7 @@
 export const PFC_CONFIG = {
   apiBase: import.meta.env.VITE_API_BASE,
   redirectUri: import.meta.env.VITE_REDIRECT_URI,
-  discordClientId: import.meta.env.VITE_DISCORD_CLIENT_ID
+  discordClientId: import.meta.env.VITE_DISCORD_CLIENT_ID,
+  // Global debug flag to control verbose logging
+  debug: import.meta.env.VITE_DEBUG === 'true'
 };

--- a/src/home.js
+++ b/src/home.js
@@ -2,16 +2,18 @@
 // js/home.js
 import { PFC_CONFIG } from './config.js'
 
+const DEBUG = PFC_CONFIG.debug;
+
 async function loadContent(sectionId) {
   try {
     const url = `${PFC_CONFIG.apiBase}/api/content/${sectionId}`;
-    console.log(`[DEBUG] Requesting: ${url}`);
+    if (DEBUG) console.log(`[DEBUG] Requesting: ${url}`);
 
     const res = await fetch(url);
     if (!res.ok) throw new Error(`API call failed with status ${res.status}`);
 
     const data = await res.json();
-    console.log(`[DEBUG] Received for ${sectionId}:`, data);
+    if (DEBUG) console.log(`[DEBUG] Received for ${sectionId}:`, data);
 
     const target = document.getElementById(sectionId);
     if (!target) {

--- a/src/log-search.js
+++ b/src/log-search.js
@@ -1,5 +1,7 @@
 import { PFC_CONFIG } from './config.js'
 
+const DEBUG = PFC_CONFIG.debug;
+
 let allCommands = [];
 let allMembers = [];
 
@@ -92,7 +94,7 @@ function renderResults(logs = []) {
 }
 
 async function searchLogs(e) {
-  console.log('[DEBUG] searchLogs() called');
+  if (DEBUG) console.log('[DEBUG] searchLogs() called');
   e?.preventDefault();
   const token = localStorage.getItem('jwt');
   const headers = token ? { Authorization: `Bearer ${token}` } : {};
@@ -109,7 +111,7 @@ async function searchLogs(e) {
   if (message) params.set('message', message);
 
   const url = `${PFC_CONFIG.apiBase}/api/activity-log/search?${params.toString()}`;
-  console.log('[DEBUG] Search URL:', url);
+  if (DEBUG) console.log('[DEBUG] Search URL:', url);
   try {
     const res = await fetch(url, { headers });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);

--- a/src/main.js
+++ b/src/main.js
@@ -2,21 +2,24 @@ import './style.css'
 import { runIncludes } from './includes.js'
 import * as nav from './nav.js'
 import * as router from './router.js'
-import {finishDiscordLogin, startDiscordLogin, logout, getUser} from './auth.js'
+import { finishDiscordLogin, startDiscordLogin, logout, getUser } from './auth.js'
 import { slugify } from './utils.js'
+import { PFC_CONFIG } from './config.js'
+
+const DEBUG = PFC_CONFIG.debug;
 
 // Log boot
-console.log('[MAIN] Booting up...')
+if (DEBUG) console.log('[MAIN] Booting up...')
 
 // Wait for DOM to be ready
 window.addEventListener('DOMContentLoaded', async () => {
-  console.log('[MAIN] DOM loaded')
+  if (DEBUG) console.log('[MAIN] DOM loaded')
 
   // Handle Discord OAuth code if present
   const urlParams = new URLSearchParams(window.location.search)
   const code = urlParams.get('code')
   if (code) {
-    console.log('[Auth] OAuth code found, finishing login...')
+    if (DEBUG) console.log('[Auth] OAuth code found, finishing login...')
     try {
       await finishDiscordLogin()
     } catch (err) {
@@ -29,5 +32,5 @@ window.addEventListener('DOMContentLoaded', async () => {
   nav.init()
   router.init()
 
-  console.log('[MAIN] Booted up successfully')
+  if (DEBUG) console.log('[MAIN] Booted up successfully')
 })

--- a/src/nav.js
+++ b/src/nav.js
@@ -1,6 +1,9 @@
 import { startDiscordLogin, logout, getUser } from './auth.js';
+import { PFC_CONFIG } from './config.js';
 
-console.log('[nav] Script start');
+const DEBUG = PFC_CONFIG.debug;
+
+if (DEBUG) console.log('[nav] Script start');
 
 // Wait until all nav elements are present in DOM
 async function waitForNavElements(timeout = 1000) {
@@ -18,7 +21,7 @@ async function waitForNavElements(timeout = 1000) {
 const show = id => {
   const el = document.getElementById(id);
   if (el) {
-    console.log(`[nav] Showing ${id}`);
+    if (DEBUG) console.log(`[nav] Showing ${id}`);
     el.classList.remove('hidden');
   }
 };
@@ -26,7 +29,7 @@ const show = id => {
 const hide = id => {
   const el = document.getElementById(id);
   if (el) {
-    console.log(`[nav] Hiding ${id}`);
+    if (DEBUG) console.log(`[nav] Hiding ${id}`);
     el.classList.add('hidden');
     if (id === 'user-info') el.classList.remove('lg:inline-block');
   }
@@ -34,21 +37,21 @@ const hide = id => {
 
 function runNavLogic() {
   const token = localStorage.getItem('jwt');
-  console.log('[nav] Token:', token);
+  if (DEBUG) console.log('[nav] Token:', token);
 
   waitForNavElements().then(() => {
     let user = null;
     if (token) {
       try {
         user = getUser();
-        console.log('[nav] User:', user);
+        if (DEBUG) console.log('[nav] User:', user);
       } catch (err) {
         console.warn('[nav] Failed to get user:', err);
       }
     }
 
     const isAdmin = user?.roles?.includes('Server Admin');
-    console.log('[nav] Is admin:', isAdmin);
+    if (DEBUG) console.log('[nav] Is admin:', isAdmin);
 
     document.getElementById('login-btn')?.addEventListener('click', startDiscordLogin);
     document.getElementById('login-btn-mobile')?.addEventListener('click', startDiscordLogin);
@@ -69,7 +72,7 @@ function runNavLogic() {
         hide('admin-link'); hide('admin-link-mobile');
         hide('admin-container');
         if (window.location.pathname.includes('admin.html')) {
-          console.log('[nav] Redirecting non-admin');
+          if (DEBUG) console.log('[nav] Redirecting non-admin');
           navigateTo('./unauthorized.html');
         }
       }
@@ -80,37 +83,37 @@ function runNavLogic() {
       hide('admin-link'); hide('admin-link-mobile');
       hide('admin-container');
       if (window.location.pathname.includes('admin.html')) {
-        console.log('[nav] Redirecting unauthenticated user');
+        if (DEBUG) console.log('[nav] Redirecting unauthenticated user');
         navigateTo('./unauthorized.html');
       }
     }
 
-    console.log('[nav] Logic complete');
+    if (DEBUG) console.log('[nav] Logic complete');
   });
 }
 
 // Attach hamburger toggle once DOM is ready
 document.addEventListener('nav-ready', () => {
-  console.log('[nav] nav-ready fired');
+  if (DEBUG) console.log('[nav] nav-ready fired');
   runNavLogic();
 });
 
 document.addEventListener('login-success', () => {
-  console.log('[nav] login-success event received — rerunning logic');
+  if (DEBUG) console.log('[nav] login-success event received — rerunning logic');
   runNavLogic();
 });
 
 // Hamburger toggle support
 document.addEventListener('nav-ready', () => {
-  console.log('[nav] nav-ready fired');
+  if (DEBUG) console.log('[nav] nav-ready fired');
 
   const toggle = document.getElementById('nav-toggle');
   const menu = document.getElementById('nav-menu-mobile');
 
   if (toggle && menu) {
-    console.log('[nav] Hamburger elements found — binding toggle');
+    if (DEBUG) console.log('[nav] Hamburger elements found — binding toggle');
     toggle.addEventListener('click', () => {
-      console.log('[nav] Toggling mobile menu');
+      if (DEBUG) console.log('[nav] Toggling mobile menu');
       menu.classList.toggle('hidden');
       menu.style.maxHeight = menu.classList.contains('hidden') ? null : menu.scrollHeight + 'px';
     });

--- a/src/router.js
+++ b/src/router.js
@@ -1,4 +1,7 @@
 import { getUser } from './auth.js';
+import { PFC_CONFIG } from './config.js';
+
+const DEBUG = PFC_CONFIG.debug;
 
 // router.js
 const routes = {
@@ -37,8 +40,8 @@ async function loadRoute() {
     return;
   }
 
-  console.log(`[router] path: ${path}`);
-  console.log(`[router] route: ${route}`);
+  if (DEBUG) console.log(`[router] path: ${path}`);
+  if (DEBUG) console.log(`[router] route: ${route}`);
 
   // Special case: protect /admin
   if (path === '/admin' || path === '/log-search') {
@@ -53,7 +56,7 @@ async function loadRoute() {
   }
 
   try {
-    console.log(`[router] fetching: /${route}`);
+    if (DEBUG) console.log(`[router] fetching: /${route}`);
     const res = await fetch('/' + route);
     if (!res.ok) throw new Error('Failed to fetch view: ' + route);
 
@@ -76,28 +79,28 @@ async function loadRoute() {
 
     // Load matching script module
     if (path.includes('accolades')) {
-      console.log('[router] importing accolades.js');
+      if (DEBUG) console.log('[router] importing accolades.js');
       import('./accolades.js').then(m => m.init?.());
     } else if (path.includes('accolade')) {
-      console.log('[router] importing accolade.js');
+      if (DEBUG) console.log('[router] importing accolade.js');
       import('./accolade.js').then(m => m.init?.());
     } else if (path.includes('events')) {
-      console.log('[router] importing events.js');
+      if (DEBUG) console.log('[router] importing events.js');
       import('./events.js').then(m => m.init?.());
     } else if (path.includes('admin')) {
-      console.log('[router] importing admin.js');
+      if (DEBUG) console.log('[router] importing admin.js');
       import('./admin.js').then(m => m.init?.());
     } else if (path.includes('log-search')) {
-      console.log('[router] importing log-search.js');
+      if (DEBUG) console.log('[router] importing log-search.js');
       import('./log-search.js').then(m => m.init?.());
     } else if (path.includes('unauthorized')) {
-      console.log('[router] importing unauthorized.js');
+      if (DEBUG) console.log('[router] importing unauthorized.js');
       import('./unauthorized.js').then(m => m.init?.());
     } else if (path === '/' || path === '/home') {
-      console.log('[router] importing home.js');
+      if (DEBUG) console.log('[router] importing home.js');
       import('./home.js').then(m => m.init?.());
     } else if (path.startsWith('/shop') || path.startsWith('/product/')) {
-      console.log('[router] importing shop.js');
+      if (DEBUG) console.log('[router] importing shop.js');
       import('./shop.js').then(m => m.init?.(path));
     }
   } catch (err) {

--- a/src/unauthorized.js
+++ b/src/unauthorized.js
@@ -1,12 +1,16 @@
+import { PFC_CONFIG } from './config.js';
+
+const DEBUG = PFC_CONFIG.debug;
+
 export async function init() {
-    console.log('[unauthorized.js] Init called');
-  
-    // Optional: Add any interactive behaviour here
-    const homeBtn = document.querySelector('a[data-link]');
-    homeBtn?.addEventListener('click', e => {
-      e.preventDefault();
-      history.pushState(null, null, '/');
-      loadInitialRoute(); // Should already exist in your SPA setup
-    });
-  }
-  
+  if (DEBUG) console.log('[unauthorized.js] Init called');
+
+  // Optional: Add any interactive behaviour here
+  const homeBtn = document.querySelector('a[data-link]');
+  homeBtn?.addEventListener('click', e => {
+    e.preventDefault();
+    history.pushState(null, null, '/');
+    loadInitialRoute(); // Should already exist in your SPA setup
+  });
+}
+


### PR DESCRIPTION
## Summary
- add a `debug` option in config
- wrap existing console logs with a global debug flag
- clean up stray debug output

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_b_684eddefde8c832d8c33a34a4b5fa9be