### PR TITLE
Add officers page

### DIFF
--- a/public/partials/nav.html
+++ b/public/partials/nav.html
@@ -15,6 +15,7 @@
         <a href="/shop" data-link class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded text-center">Shop</a>
         <a href="/events" data-link class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded text-center">Events</a>
         <a href="/accolades" data-link class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded text-center">Accolades</a>
+        <a href="/officers" data-link class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded text-center">Officers</a>
         <a href="/admin" data-link id="admin-link-mobile" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded text-center hidden">Admin</a>
         <button id="login-btn-mobile" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded hidden">Login with Discord</button>
         <button id="logout-btn-mobile" class="bg-gray-800 hover:bg-gray-800 text-white font-bold py-2 px-6 rounded hidden">Logout</button>
@@ -28,6 +29,7 @@
       <a href="/shop" data-link class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded">Shop</a>
       <a href="/events" data-link class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded">Events</a>
       <a href="/accolades" data-link class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded">Accolades</a>
+      <a href="/officers" data-link class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded">Officers</a>
       <a href="/admin" data-link id="admin-link" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded hidden">Admin</a>
       <button id="login-btn" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded hidden">Login with Discord</button>
       <button id="logout-btn" class="bg-gray-800 hover:bg-gray-800 text-white font-bold py-2 px-6 rounded hidden">Logout</button>

--- a/public/views/officers.html
+++ b/public/views/officers.html
@@ -1,0 +1,4 @@
+<section class="py-16 px-6 text-center">
+  <h1 class="text-4xl font-bold text-pfc-red mb-8">Corps Leadership</h1>
+  <div id="officer-list" class="max-w-4xl mx-auto"></div>
+</section>

--- a/src/officers.js
+++ b/src/officers.js
@@ -1,0 +1,54 @@
+import { PFC_CONFIG } from './config.js';
+
+/**
+ * Fetch the list of officers from the API and render them.
+ */
+async function loadOfficers() {
+  const container = document.getElementById('officer-list');
+  if (!container) return;
+
+  const token = localStorage.getItem('jwt');
+  if (!token) {
+    container.innerHTML = '<p class="text-gray-300">Please log in to view officers.</p>';
+    return;
+  }
+
+  try {
+    const res = await fetch(`${PFC_CONFIG.apiBase}/api/officers`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    const officers = Array.isArray(data.officers) ? data.officers : [];
+
+    if (officers.length === 0) {
+      container.innerHTML = '<p class="text-gray-300">No officer data available.</p>';
+      return;
+    }
+
+    container.innerHTML = officers.map(officer => {
+      const roleColor = officer.color || '#fff';
+      const bio = officer.bio && officer.bio.trim()
+        ? `<p class="text-gray-300 mt-2">${officer.bio}</p>`
+        : '<p class="text-gray-500 italic mt-2">No biography available.</p>';
+      return `
+        <div class="card">
+          <h3 style="color: ${roleColor};">${officer.displayName}</h3>
+          <p class="font-semibold" style="color: ${roleColor};">${officer.role}</p>
+          ${bio}
+        </div>
+      `;
+    }).join('');
+  } catch (err) {
+    console.error('[officers] Failed to load officers:', err);
+    container.innerHTML = '<p class="text-red-500">Failed to load officer data.</p>';
+  }
+}
+
+/**
+ * Initialise the officers view.
+ */
+export async function init() {
+  await loadOfficers();
+}

--- a/src/router.js
+++ b/src/router.js
@@ -9,6 +9,7 @@ const routes = {
   '/accolades': 'views/accolades.html',
   '/accolade': 'views/accolade.html',
   '/events': 'views/events.html',
+  '/officers': 'views/officers.html',
   '/admin': 'views/admin.html',
   '/log-search': 'views/log-search.html',
   '/unauthorized': 'views/unauthorized.html',
@@ -87,6 +88,9 @@ async function loadRoute() {
     } else if (path.includes('events')) {
       if (DEBUG) console.log('[router] importing events.js');
       import('./events.js').then(m => m.init?.());
+    } else if (path.includes('officers')) {
+      if (DEBUG) console.log('[router] importing officers.js');
+      import('./officers.js').then(m => m.init?.());
     } else if (path.includes('admin')) {
       if (DEBUG) console.log('[router] importing admin.js');
       import('./admin.js').then(m => m.init?.());


### PR DESCRIPTION
## Summary
- add a new officers page
- create an officers data loader that requires JWT
- update router for the new view
- add navigation links to the officers page

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_b_684ee34a4c34832db3e1d68ec7336a09