### PR TITLE
Fix shop config fallback

### DIFF
--- a/src/api/shopify.js
+++ b/src/api/shopify.js
@@ -1,9 +1,11 @@
 // src/api/shopify.js
 
+import { PFC_CONFIG } from '../config.js';
+
 // Shopify store domain, e.g. "example.myshopify.com"
-const SHOPIFY_DOMAIN = import.meta.env.VITE_SHOPIFY_DOMAIN;
+const SHOPIFY_DOMAIN = PFC_CONFIG.shopifyDomain;
 // Storefront access token generated from the Shopify admin
-const STOREFRONT_TOKEN = import.meta.env.VITE_SHOPIFY_STOREFRONT_TOKEN;
+const STOREFRONT_TOKEN = PFC_CONFIG.shopifyStorefrontToken;
 
 /**
  * Execute a GraphQL query against the Shopify Storefront API.

--- a/src/config.example.js
+++ b/src/config.example.js
@@ -10,5 +10,7 @@ window.PFC_CONFIG = {
   apiBase: "https://api.example.com",
   redirectUri: "https://yourdomain.com/index.html",
   discordClientId: "YOUR_DISCORD_CLIENT_ID",
+  shopifyDomain: "example.myshopify.com",
+  shopifyStorefrontToken: "STOREFRONT_TOKEN",
   debug: false
 };

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,20 @@
+// src/config.js
+
+// Allow runtime configuration via a global object while preferring Vite env vars
+const globalConfig = typeof window !== 'undefined' ? window.PFC_CONFIG || {} : {};
+
+/**
+ * Application-wide configuration settings.
+ * Values come from Vite environment variables with optional global fallbacks.
+ */
 export const PFC_CONFIG = {
-  apiBase: import.meta.env.VITE_API_BASE,
-  redirectUri: import.meta.env.VITE_REDIRECT_URI,
-  discordClientId: import.meta.env.VITE_DISCORD_CLIENT_ID,
+  apiBase: import.meta.env.VITE_API_BASE || globalConfig.apiBase,
+  redirectUri: import.meta.env.VITE_REDIRECT_URI || globalConfig.redirectUri,
+  discordClientId:
+    import.meta.env.VITE_DISCORD_CLIENT_ID || globalConfig.discordClientId,
+  shopifyDomain: import.meta.env.VITE_SHOPIFY_DOMAIN || globalConfig.shopifyDomain,
+  shopifyStorefrontToken:
+    import.meta.env.VITE_SHOPIFY_STOREFRONT_TOKEN || globalConfig.shopifyStorefrontToken,
   // Global debug flag to control verbose logging
-  debug: import.meta.env.VITE_DEBUG === 'true'
+  debug: (import.meta.env.VITE_DEBUG === 'true') || globalConfig.debug || false
 };


### PR DESCRIPTION
## Summary
- support shopify settings in global config
- import config values in Shopify API helper
- extend config example with shopify fields

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_b_684ee931842c832daef46d024ece7447