### PR TITLE
Fix content manager dropdown

### DIFF
--- a/src/content-manager.js
+++ b/src/content-manager.js
@@ -14,7 +14,10 @@ async function loadSections() {
 
     // Normalise potential API response shapes into an array of objects
     let items = [];
-    if (Array.isArray(data.content)) {
+    if (Array.isArray(data.sections)) {
+      // { sections: ['about', 'motto'] }
+      items = data.sections.map(s => ({ key: s }));
+    } else if (Array.isArray(data.content)) {
       items = data.content;
     } else if (Array.isArray(data.contents)) {
       items = data.contents;


### PR DESCRIPTION
## Summary
- parse `sections` array from the API when building the section dropdown

## Testing
- `npm run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_b_684ef9a62e3c832d840273887f410dc7