### PR TITLE
Handle JWT expiration

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -1,6 +1,37 @@
-import { PFC_CONFIG } from "./config";
+import { PFC_CONFIG } from './config.js';
 
 const DEBUG = PFC_CONFIG.debug;
+
+/**
+ * Decode a JWT and return its payload.
+ *
+ * @param {string} token - JWT string
+ * @returns {object} Decoded payload
+ */
+function decodeJwt(token) {
+  return JSON.parse(atob(token.split('.')[1]));
+}
+
+/**
+ * Set a timeout to automatically log out when the JWT expires.
+ */
+function scheduleExpiryCheck() {
+  const token = localStorage.getItem('jwt');
+  if (!token) return;
+
+  try {
+    const payload = decodeJwt(token);
+    if (!payload.exp) return;
+    const msUntilExpiry = payload.exp * 1000 - Date.now();
+    if (msUntilExpiry <= 0) {
+      logout();
+    } else {
+      setTimeout(logout, msUntilExpiry);
+    }
+  } catch (err) {
+    console.warn('[auth] Failed to schedule expiry check:', err);
+  }
+}
 
 function finishDiscordLogin() {
   if (DEBUG) console.log('finishDiscordLogin triggered.');
@@ -31,6 +62,8 @@ function finishDiscordLogin() {
       if (data && data.token) {
         localStorage.setItem('jwt', data.token);
         if (DEBUG) console.log('✅ JWT stored:', data.token);
+        scheduleExpiryCheck();
+        document.dispatchEvent(new Event('login-success'));
       } else {
         console.warn('[auth] No token received from API:', data);
       }
@@ -45,7 +78,11 @@ function getUser() {
   try {
     const token = localStorage.getItem('jwt');
     if (!token || token === 'undefined') return null;
-    const payload = JSON.parse(atob(token.split('.')[1]));
+    const payload = decodeJwt(token);
+    if (payload.exp && Date.now() >= payload.exp * 1000) {
+      logout();
+      return null;
+    }
     return payload;
   } catch (err) {
     console.warn('[auth] Failed to decode JWT:', err);
@@ -77,6 +114,7 @@ export {
   finishDiscordLogin,
   getUser,
   startDiscordLogin,
-  logout
+  logout,
+  scheduleExpiryCheck
 };
 

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,7 @@ import { runIncludes } from './includes.js'
 import * as nav from './nav.js'
 import * as router from './router.js'
 import { PFC_CONFIG } from './config.js'
-import { finishDiscordLogin } from './auth.js'
+import { finishDiscordLogin, scheduleExpiryCheck } from './auth.js'
 
 const DEBUG = PFC_CONFIG.debug;
 
@@ -29,6 +29,7 @@ window.addEventListener('DOMContentLoaded', async () => {
   // Load nav, includes, and routes
   runIncludes()
   nav.init()
+  scheduleExpiryCheck()
   router.init()
 
   if (DEBUG) console.log('[MAIN] Booted up successfully')


### PR DESCRIPTION
## Summary
- logout automatically when the stored token expires
- monitor the token and schedule a logout on startup

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_b_68515d70f250832dbc60f7b61b69165d