### PR TITLE
Add Friends page

### DIFF
--- a/public/partials/nav.html
+++ b/public/partials/nav.html
@@ -16,6 +16,7 @@
         <a href="/events" data-link class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded text-center">Events</a>
         <a href="/accolades" data-link class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded text-center">Accolades</a>
         <a href="/officers" data-link class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded text-center">Officers</a>
+        <a href="/friends" data-link class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded text-center">Friends</a>
         <a href="/admin" data-link id="admin-link-mobile" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded text-center hidden">Admin</a>
         <button id="login-btn-mobile" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded hidden">Login with Discord</button>
         <button id="logout-btn-mobile" class="bg-gray-800 hover:bg-gray-800 text-white font-bold py-2 px-6 rounded hidden">Logout</button>
@@ -30,6 +31,7 @@
       <a href="/events" data-link class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded">Events</a>
       <a href="/accolades" data-link class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded">Accolades</a>
       <a href="/officers" data-link class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded">Officers</a>
+      <a href="/friends" data-link class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded">Friends</a>
       <a href="/admin" data-link id="admin-link" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded hidden">Admin</a>
       <button id="login-btn" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded hidden">Login with Discord</button>
       <button id="logout-btn" class="bg-gray-800 hover:bg-gray-800 text-white font-bold py-2 px-6 rounded hidden">Logout</button>

--- a/public/views/friend.html
+++ b/public/views/friend.html
@@ -1,0 +1,3 @@
+<section class="py-16 px-6">
+  <div id="friend-detail" class="max-w-4xl mx-auto"></div>
+</section>

--- a/public/views/friends.html
+++ b/public/views/friends.html
@@ -1,0 +1,5 @@
+<section class="py-16 px-6 text-center">
+  <h1 class="text-4xl font-bold text-pfc-red mb-8">Our Friends & Allies</h1>
+  <p class="max-w-3xl mx-auto mb-8 text-gray-300">Meet our closest allies and partners in the Star Citizen universe.</p>
+  <div id="friends-grid" class="product-grid"></div>
+</section>

--- a/src/friend.js
+++ b/src/friend.js
@@ -1,0 +1,46 @@
+import { PFC_CONFIG } from './config.js';
+
+function getSid() {
+  const parts = window.location.pathname.split('/');
+  return parts[2] || '';
+}
+
+async function loadFriend() {
+  const sid = getSid();
+  const container = document.getElementById('friend-detail');
+  if (!container) return;
+  if (!sid) {
+    container.innerHTML = '<p class="text-red-500">Invalid organisation id.</p>';
+    return;
+  }
+  try {
+    const res = await fetch(`${PFC_CONFIG.apiBase}/api/orgs/${sid}`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const org = await res.json();
+    container.innerHTML = `
+      <div class="mb-4">
+        <div class="w-full h-40 bg-cover bg-center rounded" style="background-image:url('${org.banner}')"></div>
+      </div>
+      <img src="${org.logo}" alt="${org.name} logo" class="w-32 h-32 object-contain mx-auto mb-4" />
+      <h2 class="text-3xl font-bold text-center mb-2">${org.name}</h2>
+      <div class="text-gray-300 mb-4">${org.headline.html || ''}</div>
+      <div class="text-left space-y-4">
+        <div>${org.manifesto.html || ''}</div>
+        <details><summary class="cursor-pointer">Charter</summary>${org.charter.html || ''}</details>
+        <details><summary class="cursor-pointer">History</summary>${org.history.html || ''}</details>
+        <p class="mt-2">Members: ${org.members}</p>
+        <p>${org.recruiting ? 'Actively Recruiting' : 'Not Recruiting'}</p>
+        <div class="mt-4 space-x-4">
+          <a href="${org.url}" target="_blank" class="underline">RSI Org Page</a>
+        </div>
+      </div>
+    `;
+  } catch (err) {
+    console.error('[friend] Failed to load org:', err);
+    container.innerHTML = '<p class="text-red-500">Failed to load organisation.</p>';
+  }
+}
+
+export async function init() {
+  await loadFriend();
+}

--- a/src/friends.js
+++ b/src/friends.js
@@ -1,0 +1,39 @@
+import { PFC_CONFIG } from './config.js';
+
+/**
+ * Render friend organisations as cards in a responsive grid.
+ */
+async function loadFriends() {
+  const container = document.getElementById('friends-grid');
+  if (!container) return;
+  try {
+    const res = await fetch(`${PFC_CONFIG.apiBase}/api/orgs`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const { orgs } = await res.json();
+    if (!Array.isArray(orgs) || orgs.length === 0) {
+      container.innerHTML = '<p class="text-gray-300">No organisations found.</p>';
+      return;
+    }
+
+    container.innerHTML = orgs.map(org => {
+      const recruiting = org.recruiting ? '<span class="badge ml-2">Recruiting</span>' : '';
+      return `
+        <div class="card flex flex-col items-center text-center">
+          <div class="w-full h-32 bg-cover bg-center mb-4 rounded" style="background-image:url('${org.banner}')"></div>
+          <img src="${org.logo}" alt="${org.name} logo" class="w-24 h-24 object-contain mb-2" />
+          <h3 class="text-xl font-bold">${org.name}</h3>
+          <p class="text-sm text-gray-300 mb-2">${org.headline.plaintext || ''}</p>
+          <p class="text-sm mb-2">Members: ${org.members}${recruiting}</p>
+          <a data-link href="/friends/${org.sid}" class="button mt-auto">Learn More</a>
+        </div>
+      `;
+    }).join('');
+  } catch (err) {
+    console.error('[friends] Failed to load orgs:', err);
+    container.innerHTML = '<p class="text-red-500">Failed to load organisations.</p>';
+  }
+}
+
+export async function init() {
+  await loadFriends();
+}

--- a/src/router.js
+++ b/src/router.js
@@ -10,12 +10,14 @@ const routes = {
   '/accolade': 'views/accolade.html',
   '/events': 'views/events.html',
   '/officers': 'views/officers.html',
+  '/friends': 'views/friends.html',
   '/admin': 'views/admin.html',
   '/log-search': 'views/log-search.html',
   '/content-manager': 'views/content-manager.html',
   '/unauthorized': 'views/unauthorized.html',
   '/shop': 'views/shop.html',
-  '/product/:handle': 'views/shop.html'
+  '/product/:handle': 'views/shop.html',
+  '/friends/:sid': 'views/friend.html'
 };
 
 export function navigateTo(url) {
@@ -30,6 +32,8 @@ async function loadRoute() {
   if (!route) {
     if (path.startsWith('/product/')) {
       route = routes['/product/:handle'];
+    } else if (path.startsWith('/friends/')) {
+      route = routes['/friends/:sid'];
     } else {
       route = routes['/'];
     }
@@ -96,6 +100,12 @@ async function loadRoute() {
     } else if (path.includes('officers')) {
       if (DEBUG) console.log('[router] importing officers.js');
       import('./officers.js').then(m => m.init?.());
+    } else if (path.startsWith('/friends/')) {
+      if (DEBUG) console.log('[router] importing friend.js');
+      import('./friend.js').then(m => m.init?.());
+    } else if (path.includes('friends')) {
+      if (DEBUG) console.log('[router] importing friends.js');
+      import('./friends.js').then(m => m.init?.());
     } else if (path.includes('admin')) {
       if (DEBUG) console.log('[router] importing admin.js');
       import('./admin.js').then(m => m.init?.());


### PR DESCRIPTION
## Summary
- add a Friends link in the nav
- create /friends page and fetch org list from API
- support individual org detail pages
- route to the new pages via router

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_b_68516f03706c832db07294917619500d