### PR TITLE
Add WYSIWYG editor to content manager

### DIFF
--- a/public/views/content-manager.html
+++ b/public/views/content-manager.html
@@ -8,7 +8,8 @@
     </div>
     <div>
       <label for="content-area" class="block text-white mb-1">Content</label>
-      <textarea id="content-area" rows="10" class="w-full p-2 rounded bg-gray-200"></textarea>
+      <div id="editor-toolbar" class="editor-toolbar flex flex-wrap mb-2"></div>
+      <div id="content-area" contenteditable="true" class="w-full p-2 rounded bg-gray-200 text-black h-64 overflow-y-auto"></div>
     </div>
     <button id="save-button" type="button" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded">Save Changes</button>
   </div>

--- a/src/content-manager.js
+++ b/src/content-manager.js
@@ -42,28 +42,28 @@ async function loadSections() {
   }
 }
 
-// Retrieve a section's content and populate the textarea.
+// Retrieve a section's content and populate the editor.
 async function loadContent(section) {
-  const textarea = document.getElementById('content-area');
+  const editor = document.getElementById('content-area');
   const errorEl = document.getElementById('content-error');
-  if (!textarea) return;
+  if (!editor) return;
   try {
     const res = await fetch(`${PFC_CONFIG.apiBase}/api/content/${section}`);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
-    textarea.value = data.content || data.value || '';
+    editor.innerHTML = data.content || data.value || '';
   } catch (err) {
     console.error(`[content-manager] Failed to load content for ${section}`, err);
     if (errorEl) errorEl.textContent = `Failed to load content for ${section}.`;
-    textarea.value = '';
+    editor.innerHTML = '';
   }
 }
 
-// Save the textarea contents back to the API for a given section.
+// Save the editor contents back to the API for a given section.
 async function saveContent(section) {
-  const textarea = document.getElementById('content-area');
+  const editor = document.getElementById('content-area');
   const errorEl = document.getElementById('content-error');
-  if (!textarea) return;
+  if (!editor) return;
   const token = localStorage.getItem('jwt');
   const headers = { 'Content-Type': 'application/json' };
   if (token) headers.Authorization = `Bearer ${token}`;
@@ -71,7 +71,7 @@ async function saveContent(section) {
     const res = await fetch(`${PFC_CONFIG.apiBase}/api/content/${section}`, {
       method: 'PUT',
       headers,
-      body: JSON.stringify({ content: textarea.value })
+      body: JSON.stringify({ content: editor.innerHTML })
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     if (errorEl) errorEl.textContent = 'Content saved.';
@@ -89,17 +89,35 @@ export async function init() {
   try {
     await loadSections();
     const select = document.getElementById('section-select');
-    const textarea = document.getElementById('content-area');
+    const editor = document.getElementById('content-area');
+    const toolbar = document.getElementById('editor-toolbar');
     const saveBtn = document.getElementById('save-button');
+
+    if (toolbar) {
+      toolbar.innerHTML = `
+        <button type="button" data-cmd="bold"><i class="fas fa-bold"></i></button>
+        <button type="button" data-cmd="italic"><i class="fas fa-italic"></i></button>
+        <button type="button" data-cmd="underline"><i class="fas fa-underline"></i></button>
+        <button type="button" data-cmd="insertUnorderedList"><i class="fas fa-list-ul"></i></button>`;
+
+      toolbar.addEventListener('click', e => {
+        const btn = e.target.closest('button');
+        if (!btn) return;
+        const cmd = btn.dataset.cmd;
+        if (!cmd) return;
+        document.execCommand(cmd, false, null);
+        editor?.focus();
+      });
+    }
 
     select?.addEventListener('change', e => {
       const value = e.target.value;
       document.getElementById('content-error').textContent = '';
       if (value) {
         loadContent(value);
-        textarea?.focus();
-      } else if (textarea) {
-        textarea.value = '';
+        editor?.focus();
+      } else if (editor) {
+        editor.innerHTML = '';
       }
     });
 

--- a/src/style.css
+++ b/src/style.css
@@ -180,5 +180,19 @@
     margin-bottom: 2rem;
   }
 
+.editor-toolbar button {
+  background-color: #333;
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  margin-right: 0.25rem;
+  border-radius: 0.25rem;
+  border: 1px solid #444;
+  font-size: 0.875rem;
+}
+
+.editor-toolbar button:hover {
+  background-color: #555;
+}
+
   
   


### PR DESCRIPTION
## Summary
- replace textarea with contenteditable div
- add formatting toolbar for common commands
- update JS logic to load and save HTML
- style new toolbar in CSS

## Testing
- `npm run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_b_6851814751d4832da7f8c73cd8bd64ab