### PR TITLE
Fix friend org page with updated API response

### DIFF
--- a/src/friend.js
+++ b/src/friend.js
@@ -20,7 +20,9 @@ async function loadFriend() {
     const headers = token ? { Authorization: `Bearer ${token}` } : {};
     const res = await fetch(`${PFC_CONFIG.apiBase}/api/orgs/${sid}`, { headers });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const org = await res.json();
+    const data = await res.json();
+    // API may return { org: {...} }, but older versions returned the object
+    const org = data.org || data;
     container.innerHTML = `
       <div class="mb-4">
         <div class="w-full h-40 bg-cover bg-center rounded" style="background-image:url('${org.banner}')"></div>


### PR DESCRIPTION
## Summary
- handle updated API response for org details

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_b_685182d1bd24832dabddcbf14d1a553b