### PR TITLE
Hide PFCS in friends list

### DIFF
--- a/src/friends.js
+++ b/src/friends.js
@@ -15,7 +15,12 @@ async function loadFriends() {
       return;
     }
 
-    container.innerHTML = orgs.map(org => {
+    // Filter out the PFC's own organisation from the friends list
+    const visibleOrgs = orgs.filter(org =>
+      (org.sid || '').toUpperCase() !== 'PFCS'
+    );
+
+    container.innerHTML = visibleOrgs.map(org => {
       const recruiting = org.recruiting ? '<span class="badge ml-2">Recruiting</span>' : '';
       return `
         <div class="card flex flex-col items-center text-center">


### PR DESCRIPTION
## Summary
- filter the PFC org from the friends listing so it doesn't appear on the allies page

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_b_6851863d9914832d95240d98f21dd658