### PR TITLE
Enable font color selection in content editor

### DIFF
--- a/public/views/content-manager.html
+++ b/public/views/content-manager.html
@@ -7,8 +7,11 @@
       <select id="section-select" class="w-full p-2 rounded"></select>
     </div>
     <div>
-      <label for="content-area" class="block text-white mb-1">Content</label>
-      <textarea id="content-area" rows="10" class="w-full p-2 rounded bg-gray-200"></textarea>
+      <label for="content-editor" class="block text-white mb-1">Content</label>
+      <div class="wysiwyg-toolbar mb-2 flex gap-2">
+        <input type="color" id="font-color" title="Font colour" />
+      </div>
+      <div id="content-editor" class="w-full p-2 rounded bg-gray-200 wysiwyg-editor" contenteditable="true"></div>
     </div>
     <button id="save-button" type="button" class="bg-pfc-red hover:bg-red-800 text-white font-bold py-2 px-4 rounded">Save Changes</button>
   </div>

--- a/src/content-manager.js
+++ b/src/content-manager.js
@@ -1,4 +1,5 @@
 import { PFC_CONFIG } from './config.js';
+import { initEditor } from './editor.js';
 
 const DEBUG = PFC_CONFIG.debug;
 
@@ -44,26 +45,26 @@ async function loadSections() {
 
 // Retrieve a section's content and populate the textarea.
 async function loadContent(section) {
-  const textarea = document.getElementById('content-area');
+  const editor = document.getElementById('content-editor');
   const errorEl = document.getElementById('content-error');
-  if (!textarea) return;
+  if (!editor) return;
   try {
     const res = await fetch(`${PFC_CONFIG.apiBase}/api/content/${section}`);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
-    textarea.value = data.content || data.value || '';
+    editor.innerHTML = data.content || data.value || '';
   } catch (err) {
     console.error(`[content-manager] Failed to load content for ${section}`, err);
     if (errorEl) errorEl.textContent = `Failed to load content for ${section}.`;
-    textarea.value = '';
+    editor.innerHTML = '';
   }
 }
 
 // Save the textarea contents back to the API for a given section.
 async function saveContent(section) {
-  const textarea = document.getElementById('content-area');
+  const editor = document.getElementById('content-editor');
   const errorEl = document.getElementById('content-error');
-  if (!textarea) return;
+  if (!editor) return;
   const token = localStorage.getItem('jwt');
   const headers = { 'Content-Type': 'application/json' };
   if (token) headers.Authorization = `Bearer ${token}`;
@@ -71,7 +72,7 @@ async function saveContent(section) {
     const res = await fetch(`${PFC_CONFIG.apiBase}/api/content/${section}`, {
       method: 'PUT',
       headers,
-      body: JSON.stringify({ content: textarea.value })
+      body: JSON.stringify({ content: editor.innerHTML })
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     if (errorEl) errorEl.textContent = 'Content saved.';
@@ -89,7 +90,8 @@ export async function init() {
   try {
     await loadSections();
     const select = document.getElementById('section-select');
-    const textarea = document.getElementById('content-area');
+    const editor = document.getElementById('content-editor');
+    initEditor('content-editor', 'font-color');
     const saveBtn = document.getElementById('save-button');
 
     select?.addEventListener('change', e => {
@@ -97,9 +99,9 @@ export async function init() {
       document.getElementById('content-error').textContent = '';
       if (value) {
         loadContent(value);
-        textarea?.focus();
-      } else if (textarea) {
-        textarea.value = '';
+        editor?.focus();
+      } else if (editor) {
+        editor.innerHTML = '';
       }
     });
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -1,0 +1,20 @@
+// src/editor.js
+
+/**
+ * Initialise a basic WYSIWYG editor with font colour support.
+ * @param {string} editorId - ID of the contenteditable element
+ * @param {string} colorInputId - ID of the colour input element
+ */
+export function initEditor(editorId, colorInputId) {
+  const editor = document.getElementById(editorId);
+  const colorInput = document.getElementById(colorInputId);
+  if (!editor || !colorInput) return;
+
+  // Use inline styles for color commands
+  document.execCommand('styleWithCSS', false, true);
+
+  colorInput.addEventListener('input', e => {
+    document.execCommand('foreColor', false, e.target.value);
+    editor.focus();
+  });
+}

--- a/src/style.css
+++ b/src/style.css
@@ -180,5 +180,14 @@
     margin-bottom: 2rem;
   }
 
+  .wysiwyg-toolbar {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .wysiwyg-editor {
+    min-height: 10rem;
+  }
+
   
   


### PR DESCRIPTION
## Summary
- implement small WYSIWYG module
- switch content manager to use new editor
- support font colour selection via toolbar
- adjust styling for new editor

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_b_6851868b0ef4832d9134c526722c6f08