### PR TITLE
Fix wysiwyg toolbar functions

### DIFF
--- a/public/views/content-manager.html
+++ b/public/views/content-manager.html
@@ -8,7 +8,19 @@
     </div>
     <div>
       <label for="content-editor" class="block text-white mb-1">Content</label>
-      <div class="wysiwyg-toolbar mb-2 flex gap-2">
+      <div id="wysiwyg-toolbar" class="wysiwyg-toolbar mb-2 flex gap-2">
+        <button type="button" data-cmd="bold" title="Bold">
+          <i class="fas fa-bold"></i>
+        </button>
+        <button type="button" data-cmd="italic" title="Italic">
+          <i class="fas fa-italic"></i>
+        </button>
+        <button type="button" data-cmd="underline" title="Underline">
+          <i class="fas fa-underline"></i>
+        </button>
+        <button type="button" data-cmd="insertUnorderedList" title="Bullet list">
+          <i class="fas fa-list-ul"></i>
+        </button>
         <input type="color" id="font-color" title="Font colour" />
       </div>
       <div id="content-editor" class="w-full p-2 rounded bg-gray-200 wysiwyg-editor" contenteditable="true"></div>

--- a/src/content-manager.js
+++ b/src/content-manager.js
@@ -91,25 +91,8 @@ export async function init() {
     await loadSections();
     const select = document.getElementById('section-select');
     const editor = document.getElementById('content-editor');
-    initEditor('content-editor', 'font-color');
     const saveBtn = document.getElementById('save-button');
-
-    if (toolbar) {
-      toolbar.innerHTML = `
-        <button type="button" data-cmd="bold"><i class="fas fa-bold"></i></button>
-        <button type="button" data-cmd="italic"><i class="fas fa-italic"></i></button>
-        <button type="button" data-cmd="underline"><i class="fas fa-underline"></i></button>
-        <button type="button" data-cmd="insertUnorderedList"><i class="fas fa-list-ul"></i></button>`;
-
-      toolbar.addEventListener('click', e => {
-        const btn = e.target.closest('button');
-        if (!btn) return;
-        const cmd = btn.dataset.cmd;
-        if (!cmd) return;
-        document.execCommand(cmd, false, null);
-        editor?.focus();
-      });
-    }
+    initEditor('content-editor', 'font-color', 'wysiwyg-toolbar');
 
     select?.addEventListener('change', e => {
       const value = e.target.value;

--- a/src/editor.js
+++ b/src/editor.js
@@ -1,20 +1,37 @@
 // src/editor.js
 
 /**
- * Initialise a basic WYSIWYG editor with font colour support.
+ * Initialise a basic WYSIWYG editor.
+ * Supports font colour and simple formatting commands.
+ *
  * @param {string} editorId - ID of the contenteditable element
  * @param {string} colorInputId - ID of the colour input element
+ * @param {string} toolbarId - ID of the toolbar containing command buttons
  */
-export function initEditor(editorId, colorInputId) {
+export function initEditor(editorId, colorInputId, toolbarId) {
   const editor = document.getElementById(editorId);
+  if (!editor) return;
   const colorInput = document.getElementById(colorInputId);
-  if (!editor || !colorInput) return;
+  const toolbar = document.getElementById(toolbarId);
 
   // Use inline styles for color commands
   document.execCommand('styleWithCSS', false, true);
 
-  colorInput.addEventListener('input', e => {
-    document.execCommand('foreColor', false, e.target.value);
-    editor.focus();
-  });
+  if (colorInput) {
+    colorInput.addEventListener('input', e => {
+      document.execCommand('foreColor', false, e.target.value);
+      editor.focus();
+    });
+  }
+
+  if (toolbar) {
+    toolbar.addEventListener('click', e => {
+      const btn = e.target.closest('button[data-cmd]');
+      if (!btn) return;
+      const cmd = btn.dataset.cmd;
+      if (!cmd) return;
+      document.execCommand(cmd, false, null);
+      editor.focus();
+    });
+  }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -185,6 +185,19 @@
     gap: 0.5rem;
   }
 
+  .wysiwyg-toolbar button {
+    background-color: var(--pfc-red);
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    padding: 0.25rem 0.5rem;
+    cursor: pointer;
+  }
+
+  .wysiwyg-toolbar button:hover {
+    background-color: var(--pfc-gold);
+  }
+
   .wysiwyg-editor {
     min-height: 10rem;
   }


### PR DESCRIPTION
## Summary
- restore formatting buttons in content manager
- hook up wysiwyg toolbar with editor helper
- support optional formatting toolbar and colour input
- style buttons for visibility

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_b_68518a47de34832d9fac39760fa71ea0