### PR TITLE
Add label for color selector

### DIFF
--- a/public/views/content-manager.html
+++ b/public/views/content-manager.html
@@ -21,6 +21,9 @@
         <button type="button" data-cmd="insertUnorderedList" title="Bullet list">
           <i class="fas fa-list-ul"></i>
         </button>
+        <label for="font-color" class="text-white text-sm flex items-center">
+          Colour:
+        </label>
         <input type="color" id="font-color" title="Font colour" />
       </div>
       <div id="content-editor" class="w-full p-2 rounded bg-gray-200 wysiwyg-editor" contenteditable="true"></div>


### PR DESCRIPTION
## Summary
- label the font color picker in the WYSIWYG toolbar

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_b_68518d328b80832dab90e332862dc260