### PR TITLE
Fix friend page collapsible sections and button style

### DIFF
--- a/src/friend.js
+++ b/src/friend.js
@@ -101,6 +101,22 @@ async function loadFriend() {
         </div>
       </div>
     `;
+
+    // Manually attach toggle handlers for details in case <details> is not
+    // natively supported or another style prevents default toggling
+    container.querySelectorAll('.details-block').forEach(details => {
+      const summary = details.querySelector('.details-summary');
+      if (!summary) return;
+      summary.addEventListener('click', () => {
+        details.open = !details.open;
+      });
+      summary.addEventListener('keypress', e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          summary.click();
+        }
+      });
+    });
   } catch (err) {
     console.error('[friend] Failed to load org:', err);
     container.innerHTML = '<p class="text-red-500">Failed to load organisation.</p>';

--- a/src/style.css
+++ b/src/style.css
@@ -123,7 +123,8 @@
     margin: 1rem 0 2rem;
   }
   
-  .button {
+.button {
+    display: inline-block;
     padding: 0.5rem 1rem;
     background-color: var(--pfc-red);
     color: #fff;
@@ -132,7 +133,8 @@
     cursor: pointer;
     font-weight: 500;
     transition: background-color 0.2s ease;
-    
+    text-decoration: none;
+
   }
   
   .button:hover {


### PR DESCRIPTION
## Summary
- ensure friend page collapsible sections toggle reliably
- make button style work when CSS is loaded directly

## Testing
- `npm run build` *(fails: Cannot find module `@rollup/rollup-linux-x64-gnu`)*

------
https://chatgpt.com/codex/tasks/task_b_685192c63e38832d86700ae99730b881