### PR TITLE
Update friends page for new API layout

### DIFF
--- a/src/friend.js
+++ b/src/friend.js
@@ -40,7 +40,8 @@ async function loadFriend() {
     const res = await fetch(`${PFC_CONFIG.apiBase}/api/orgs/${sid}`, { headers });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
-    const org = data.org || data;
+    const wrapper = data.org || data;
+    const org = wrapper.data || wrapper;
 
     // Get external links
     const orgWebsite = extractUrl(org.history?.plaintext, 'Website:');

--- a/src/friends.js
+++ b/src/friends.js
@@ -16,7 +16,8 @@ async function loadFriends() {
     }
 
     // Filter out the PFC's own organisation from the friends list
-    const visibleOrgs = orgs.filter(org =>
+    const mappedOrgs = orgs.map(o => o.data || o.org || o);
+    const visibleOrgs = mappedOrgs.filter(org =>
       (org.sid || '').toUpperCase() !== 'PFCS'
     );
 


### PR DESCRIPTION
## Summary
- update friends list and detail page to parse new `org` response layout

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_b_685195da2b44832da583e50fdcbb77ff