### PR TITLE
Fix friend page collapsible toggle

### DIFF
--- a/src/friend.js
+++ b/src/friend.js
@@ -106,7 +106,8 @@ async function loadFriend() {
     container.querySelectorAll('.details-block').forEach(details => {
       const summary = details.querySelector('.details-summary');
       if (!summary) return;
-      summary.addEventListener('click', () => {
+      summary.addEventListener('click', e => {
+        e.preventDefault();
         details.open = !details.open;
       });
       summary.addEventListener('keypress', e => {


### PR DESCRIPTION
## Summary
- prevent native `<details>` toggle from being reversed by JS

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_b_68519f160734832daf920df5beb0ff30