### PR TITLE
Add Jest test setup

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,0 +1,11 @@
+import { slugify } from '../src/utils.js';
+
+describe('slugify', () => {
+  it('converts text to kebab-case', () => {
+    expect(slugify('Hello World')).toBe('hello-world');
+  });
+
+  it('removes special characters', () => {
+    expect(slugify('Hello, World!')).toBe('hello-world');
+  });
+});

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }]
+  ]
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.js$': 'babel-jest'
+  },
+  moduleDirectories: ['node_modules', 'src']
+};

--- a/package.json
+++ b/package.json
@@ -4,11 +4,15 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "license": "ISC",
   "devDependencies": {
     "vite": "^6.3.5",
-    "vite-plugin-static-copy": "^3.0.0"
+    "vite-plugin-static-copy": "^3.0.0",
+    "jest": "^29.7.0",
+    "babel-jest": "^29.7.0",
+    "@babel/preset-env": "^7.24.0"
   }
 }


### PR DESCRIPTION
## Summary
- setup Jest with babel transformation
- add basic unit test for `slugify`

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852a2e0b5b0832da779b7ee8bfdcdd2