### PR TITLE
Add Jest configuration and initial unit tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    ["@babel/preset-env", {"targets": {"node": "current"}}]
+  ]
+}

--- a/__tests__/auth.test.js
+++ b/__tests__/auth.test.js
@@ -1,0 +1,65 @@
+import fetchMock from 'jest-fetch-mock';
+
+jest.mock('../src/config.js', () => ({
+  PFC_CONFIG: { apiBase: 'https://api', redirectUri: 'https://site', debug: false }
+}));
+
+import * as auth from '../src/auth.js';
+
+describe('getUser', () => {
+  test('returns decoded payload when token valid', () => {
+    const payload = { displayName: 'Test', exp: Math.floor(Date.now()/1000)+100 };
+    const token = 'header.' + btoa(JSON.stringify(payload)) + '.sig';
+    localStorage.setItem('jwt', token);
+    expect(auth.getUser()).toEqual(payload);
+  });
+
+  test('returns null when expired and clears token', () => {
+    const payload = { exp: Math.floor(Date.now()/1000)-10 };
+    const token = 'h.' + btoa(JSON.stringify(payload)) + '.s';
+    localStorage.setItem('jwt', token);
+    const spy = jest.spyOn(auth, 'logout').mockImplementation(() => {});
+    expect(auth.getUser()).toBeNull();
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+describe('scheduleExpiryCheck', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  test('sets timeout for future expiry', () => {
+    const payload = { exp: Math.floor(Date.now()/1000)+1 };
+    const token = 'h.' + btoa(JSON.stringify(payload)) + '.s';
+    localStorage.setItem('jwt', token);
+    const spy = jest.spyOn(global, 'setTimeout');
+    auth.scheduleExpiryCheck();
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+describe('finishDiscordLogin', () => {
+  test('stores token and dispatches event', async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ token: 'abc' }));
+    delete window.location;
+    window.location = { search: '?code=123', href: 'https://site' };
+    const dispatchSpy = jest.spyOn(document, 'dispatchEvent');
+    await auth.finishDiscordLogin();
+    expect(localStorage.getItem('jwt')).toBe('abc');
+    expect(dispatchSpy).toHaveBeenCalled();
+    dispatchSpy.mockRestore();
+  });
+});
+
+describe('logout', () => {
+  test('clears storage and reloads', () => {
+    localStorage.setItem('jwt', 'x');
+    delete window.location;
+    window.location = { reload: jest.fn() };
+    auth.logout();
+    expect(localStorage.getItem('jwt')).toBeNull();
+    expect(window.location.reload).toHaveBeenCalled();
+  });
+});

--- a/__tests__/config.test.js
+++ b/__tests__/config.test.js
@@ -1,0 +1,5 @@
+test('PFC_CONFIG reads from global object', () => {
+  global.PFC_CONFIG = { apiBase: 'a' };
+  const { PFC_CONFIG: cfg } = require('../src/config.js');
+  expect(cfg.apiBase).toBe('a');
+});

--- a/__tests__/includes.test.js
+++ b/__tests__/includes.test.js
@@ -1,0 +1,16 @@
+import fetchMock from 'jest-fetch-mock';
+
+import { runIncludes } from '../src/includes.js';
+
+beforeEach(() => {
+  document.body.innerHTML = `<div data-include="nav.html"></div>`;
+  fetchMock.resetMocks();
+  fetchMock.mockResponse('<nav>nav</nav>');
+});
+
+test('inserts included content and dispatches nav-ready', async () => {
+  const spy = jest.spyOn(document, 'dispatchEvent');
+  await runIncludes();
+  expect(document.body.innerHTML).toContain('<nav>nav</nav>');
+  expect(spy).toHaveBeenCalled();
+});

--- a/__tests__/nav.test.js
+++ b/__tests__/nav.test.js
@@ -1,0 +1,28 @@
+import '../src/nav.js';
+
+jest.mock('../src/auth.js', () => ({
+  startDiscordLogin: jest.fn(),
+  logout: jest.fn(),
+  getUser: jest.fn(() => ({ displayName: 'Tester', roles: ['Fleet Admiral'] }))
+}));
+
+beforeEach(() => {
+  document.body.innerHTML = `
+    <button id="login-btn" class="hidden"></button>
+    <button id="login-btn-mobile" class="hidden"></button>
+    <button id="logout-btn" class="hidden"></button>
+    <button id="logout-btn-mobile" class="hidden"></button>
+    <span id="display-name"></span>
+    <div id="user-info" class="hidden"></div>
+    <a id="admin-link" class="hidden"></a>
+    <a id="admin-link-mobile" class="hidden"></a>
+    <div id="admin-container" class="hidden"></div>
+  `;
+  window.dispatchEvent(new Event('nav-ready'));
+});
+
+test('shows user info when logged in as admin', () => {
+  const info = document.getElementById('user-info');
+  expect(info.classList.contains('hidden')).toBe(false);
+  expect(document.getElementById('display-name').textContent).toBe('Tester');
+});

--- a/__tests__/pages.test.js
+++ b/__tests__/pages.test.js
@@ -1,0 +1,112 @@
+import fetchMock from 'jest-fetch-mock';
+
+jest.mock('../src/config.js', () => ({
+  PFC_CONFIG: { apiBase: 'https://api', debug: false, shopifyDomain: 'dom', shopifyStorefrontToken: 'tok' }
+}));
+
+import * as home from '../src/home.js';
+import * as events from '../src/events.js';
+import * as accolades from '../src/accolades.js';
+import * as accolade from '../src/accolade.js';
+import * as officers from '../src/officers.js';
+import * as friends from '../src/friends.js';
+import * as friend from '../src/friend.js';
+import * as admin from '../src/admin.js';
+import * as contentManager from '../src/content-manager.js';
+import * as logSearch from '../src/log-search.js';
+import * as unauthorized from '../src/unauthorized.js';
+import * as shop from '../src/shop.js';
+
+beforeEach(() => {
+  fetchMock.resetMocks();
+  document.body.innerHTML = '<div id="view-container"></div>';
+});
+
+test('home.init fetches sections', async () => {
+  fetchMock.mockResponse(JSON.stringify({ content: 'ok' }));
+  document.body.innerHTML = '<div id="about"></div><div id="structure"></div><div id="motto"></div>';
+  await home.init();
+  expect(fetchMock.mock.calls.length).toBe(3);
+});
+
+test('events.init handles empty list', async () => {
+  fetchMock.mockResponse(JSON.stringify({ events: [] }));
+  document.body.innerHTML = '<div id="events"></div>';
+  await events.init();
+  expect(document.getElementById('events').innerHTML).toContain('No upcoming');
+});
+
+test('accolades.init renders list', async () => {
+  fetchMock.mockResponse(JSON.stringify({ accolades: [{ name: 'Medal' }] }));
+  document.body.innerHTML = '<div id="accolade-list"></div>';
+  await accolades.init();
+  expect(document.getElementById('accolade-list').innerHTML).toContain('Medal');
+});
+
+test('accolade.init missing slug shows error', async () => {
+  fetchMock.mockResponse(JSON.stringify({ accolades: [] }));
+  document.body.innerHTML = '<div id="accolade-name"></div><div id="accolade-description"></div><div id="recipients"></div>';
+  delete window.location;
+  window.location = { search: '' };
+  await accolade.init();
+  expect(document.getElementById('accolade-name').textContent).toBe('Error');
+});
+
+test('officers.init displays message when none', async () => {
+  fetchMock.mockResponse(JSON.stringify({ officers: [] }));
+  document.body.innerHTML = '<div id="officer-list"></div>';
+  await officers.init();
+  expect(document.getElementById('officer-list').innerHTML).toContain('No officer');
+});
+
+test('friends.init handles empty list', async () => {
+  fetchMock.mockResponse(JSON.stringify({ orgs: [] }));
+  document.body.innerHTML = '<div id="friends-grid"></div>';
+  await friends.init();
+  expect(document.getElementById('friends-grid').innerHTML).toContain('No organisations');
+});
+
+test('friend.init invalid id shows error', async () => {
+  document.body.innerHTML = '<div id="friend-detail"></div>';
+  delete window.location;
+  window.location = { pathname: '/friends/' };
+  await friend.init();
+  expect(document.getElementById('friend-detail').innerHTML).toContain('Invalid');
+});
+
+test('admin.init renders with user', () => {
+  jest.mock('../src/auth.js', () => ({ getUser: () => ({ displayName: 'T' }) }));
+  document.body.innerHTML = '<div id="admin-info"></div>';
+  admin.init();
+  expect(document.getElementById('admin-info').textContent).toContain('Welcome');
+});
+
+test('contentManager.init loads entries', async () => {
+  fetchMock.mockResponse(JSON.stringify({ entries: [] }));
+  document.body.innerHTML = '<div id="cm-list"></div>';
+  await contentManager.init();
+  expect(fetchMock).toHaveBeenCalled();
+});
+
+test('logSearch.init loads logs', async () => {
+  fetchMock.mockResponse(JSON.stringify({ items: [] }));
+  document.body.innerHTML = '<div id="log-search"></div>';
+  await logSearch.init();
+  expect(fetchMock).toHaveBeenCalled();
+});
+
+test('unauthorized.init attaches handler', () => {
+  document.body.innerHTML = '<a data-link></a>';
+  unauthorized.init();
+  const link = document.querySelector('a[data-link]');
+  expect(link).toBeTruthy();
+});
+
+test('shop.init missing config shows error', async () => {
+  fetchMock.mockResponse(JSON.stringify({ products: { edges: [], pageInfo: { hasNextPage: false } } }));
+  document.body.innerHTML = '<div id="view-container"></div>';
+  const { PFC_CONFIG } = require('../src/config.js');
+  PFC_CONFIG.shopifyDomain = null;
+  await shop.init('/shop');
+  expect(document.getElementById('view-container').innerHTML).toContain('Shop is not configured');
+});

--- a/__tests__/router.test.js
+++ b/__tests__/router.test.js
@@ -1,0 +1,32 @@
+import fetchMock from 'jest-fetch-mock';
+
+jest.mock('../src/config.js', () => ({ PFC_CONFIG: { debug: false } }));
+
+jest.mock('../src/auth.js', () => ({
+  getUser: jest.fn(() => ({ roles: ['Member'] }))
+}));
+
+import * as router from '../src/router.js';
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="view-container"></div>';
+  fetchMock.resetMocks();
+});
+
+test('navigateTo pushes history and loads route', async () => {
+  fetchMock.mockResponseOnce('<div id="view-container">Home</div>');
+  const spy = jest.spyOn(history, 'pushState');
+  await router.navigateTo('/');
+  expect(spy).toHaveBeenCalled();
+  expect(fetchMock).toHaveBeenCalled();
+});
+
+
+test('admin route redirects when not admin', async () => {
+  const { getUser } = require('../src/auth.js');
+  getUser.mockResolvedValue({ roles: ['Member'] });
+  fetchMock.mockResponse('<div id="view-container"></div>');
+  await router.navigateTo('/admin');
+  // since not admin, should fetch unauthorized view
+  expect(fetchMock.mock.calls[0][0]).toContain('unauthorized');
+});

--- a/__tests__/shopify.test.js
+++ b/__tests__/shopify.test.js
@@ -1,0 +1,28 @@
+import fetchMock from 'jest-fetch-mock';
+
+jest.mock('../src/config.js', () => ({
+  PFC_CONFIG: {
+    shopifyDomain: 'example.myshopify.com',
+    shopifyStorefrontToken: 'token',
+    debug: false
+  }
+}));
+
+import { shopifyGraphQL, getCreateCheckoutMutation } from '../src/api/shopify.js';
+
+beforeEach(() => {
+  fetchMock.resetMocks();
+});
+
+test('shopifyGraphQL posts query and returns data', async () => {
+  fetchMock.mockResponseOnce(JSON.stringify({ data: { ok: true } }));
+  const result = await shopifyGraphQL('{test}');
+  expect(fetchMock).toHaveBeenCalledWith('https://example.myshopify.com/api/2023-04/graphql.json', expect.objectContaining({ method: 'POST' }));
+  expect(result).toEqual({ ok: true });
+});
+
+test('getCreateCheckoutMutation returns correct mutation string', () => {
+  const mutation = getCreateCheckoutMutation('123');
+  expect(mutation).toContain('checkoutCreate');
+  expect(mutation).toContain('variantId: "123"');
+});

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,0 +1,7 @@
+import { slugify } from '../src/utils.js';
+
+test('slugify converts strings to lowercase hyphenated slugs', () => {
+  expect(slugify('Hello World')).toBe('hello-world');
+  expect(slugify('  Multi  Word   Test ')).toBe('multi-word-test');
+  expect(slugify('Café au lait')).toBe('caf-au-lait');
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  setupFiles: ['<rootDir>/jest.setup.js'],
+  transform: {
+    '^.+\\.js$': 'babel-jest'
+  }
+};

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,2 @@
+import fetchMock from 'jest-fetch-mock';
+fetchMock.enableMocks();

--- a/package.json
+++ b/package.json
@@ -4,10 +4,16 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "license": "ISC",
   "devDependencies": {
+    "@babel/preset-env": "^7.24.0",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "jest-fetch-mock": "^4.0.2",
     "vite": "^6.3.5",
     "vite-plugin-static-copy": "^3.0.0"
   }


### PR DESCRIPTION
## Summary
- add Jest and Babel dev dependencies
- configure Jest with jsdom environment and fetch mock
- create basic test suites for utilities, auth, router, nav, includes, config, Shopify API and page modules
- provide npm `test` script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852adfe3c10832d9818d04191f3eb1b