### PR TITLE
Add tests for main and nav modules

### DIFF
--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -1,0 +1,54 @@
+import fetchMock from 'jest-fetch-mock';
+
+jest.mock('../src/config.js', () => ({ PFC_CONFIG: { debug: false } }));
+
+// stub CSS import used by main.js
+
+jest.mock('../src/includes.js', () => ({ runIncludes: jest.fn() }));
+jest.mock('../src/nav.js', () => ({ init: jest.fn() }));
+jest.mock('../src/router.js', () => ({ init: jest.fn() }));
+
+jest.mock('../src/auth.js', () => ({
+  finishDiscordLogin: jest.fn(() => Promise.resolve()),
+  scheduleExpiryCheck: jest.fn()
+}));
+
+beforeEach(() => {
+  jest.resetModules();
+  fetchMock.resetMocks();
+  const auth = require('../src/auth.js');
+  auth.finishDiscordLogin.mockClear();
+  auth.scheduleExpiryCheck.mockClear();
+  window.history.pushState({}, '', '/');
+});
+
+async function loadMain() {
+  let mods = {};
+  await jest.isolateModulesAsync(async () => {
+    mods.includes = require('../src/includes.js');
+    mods.nav = require('../src/nav.js');
+    mods.router = require('../src/router.js');
+    mods.auth = require('../src/auth.js');
+    require('../src/main.js');
+  });
+  return mods;
+}
+
+test('DOMContentLoaded initializes core modules', async () => {
+  const mods = await loadMain();
+  window.dispatchEvent(new Event('DOMContentLoaded'));
+  await new Promise(r => setTimeout(r, 0));
+  expect(mods.includes.runIncludes).toHaveBeenCalled();
+  expect(mods.nav.init).toHaveBeenCalled();
+  expect(mods.auth.scheduleExpiryCheck).toHaveBeenCalled();
+  expect(mods.router.init).toHaveBeenCalled();
+  expect(mods.auth.finishDiscordLogin).not.toHaveBeenCalled();
+});
+
+test('OAuth code triggers finishDiscordLogin', async () => {
+  window.history.pushState({}, '', '/?code=123');
+  const mods = await loadMain();
+  window.dispatchEvent(new Event('DOMContentLoaded'));
+  await new Promise(r => setTimeout(r, 0));
+  expect(mods.auth.finishDiscordLogin).toHaveBeenCalled();
+});

--- a/__tests__/nav.test.js
+++ b/__tests__/nav.test.js
@@ -1,0 +1,67 @@
+jest.mock('../src/config.js', () => ({ PFC_CONFIG: { debug: false } }));
+
+jest.mock('../src/auth.js', () => ({
+  startDiscordLogin: jest.fn(),
+  logout: jest.fn(),
+  getUser: jest.fn()
+}));
+
+beforeEach(() => {
+  jest.resetModules();
+  const auth = require('../src/auth.js');
+  auth.getUser.mockReset();
+  localStorage.clear();
+  document.body.innerHTML = `
+    <button id="login-btn" class="hidden"></button>
+    <button id="login-btn-mobile" class="hidden"></button>
+    <button id="logout-btn" class="hidden"></button>
+    <button id="logout-btn-mobile" class="hidden"></button>
+    <p id="user-info" class="hidden">Logged in as <span id="display-name"></span></p>
+    <a id="admin-link" class="hidden"></a>
+    <a id="admin-link-mobile" class="hidden"></a>
+    <div id="admin-container" class="hidden"></div>
+    <button id="nav-toggle"></button>
+    <div id="nav-menu-mobile" class="hidden"></div>
+  `;
+});
+
+async function loadNav() {
+  let mod;
+  await jest.isolateModulesAsync(async () => {
+    mod = require('../src/nav.js');
+  });
+  return mod;
+}
+
+test('shows admin elements when user is admin', async () => {
+  localStorage.setItem('jwt', 't');
+  const auth = require('../src/auth.js');
+  auth.getUser.mockReturnValue({ displayName: 'Admin', roles: ['Fleet Admiral'] });
+  const nav = await loadNav();
+  nav.init();
+  await new Promise(r => setTimeout(r, 0));
+  expect(document.getElementById('admin-link').classList.contains('hidden')).toBe(false);
+  expect(document.getElementById('admin-container').classList.contains('hidden')).toBe(false);
+  expect(document.getElementById('login-btn').classList.contains('hidden')).toBe(true);
+  expect(document.getElementById('display-name').textContent).toBe('Admin');
+});
+
+test('shows login buttons when not authenticated', async () => {
+  const nav = await loadNav();
+  nav.init();
+  await new Promise(r => setTimeout(r, 0));
+  expect(document.getElementById('login-btn').classList.contains('hidden')).toBe(false);
+  expect(document.getElementById('logout-btn').classList.contains('hidden')).toBe(true);
+  expect(document.getElementById('user-info').classList.contains('hidden')).toBe(true);
+});
+
+test('hamburger toggle hides and shows menu', async () => {
+  await loadNav();
+  document.dispatchEvent(new Event('nav-ready'));
+  const menu = document.getElementById('nav-menu-mobile');
+  const toggle = document.getElementById('nav-toggle');
+  toggle.click();
+  expect(menu.classList.contains('hidden')).toBe(false);
+  toggle.click();
+  expect(menu.classList.contains('hidden')).toBe(true);
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   moduleNameMapper: {
     // Mock CSS imports used by Vite
-    '\\.(css|less|scss|sass)$': 'identity-obj-proxy'
+    '\\.(css|less|scss|sass)$': '<rootDir>/__mocks__/styleMock.js'
   },
 
   // === TRANSFORMS ===


### PR DESCRIPTION
## Summary
- add Jest tests for main.js and nav.js
- handle CSS imports in Jest by mapping to a local mock

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6855b2196e8c832d990fd062cb080a6d