### PR TITLE
Increase nav and main test coverage

### DIFF
--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -52,3 +52,21 @@ test('OAuth code triggers finishDiscordLogin', async () => {
   await new Promise(r => setTimeout(r, 0));
   expect(mods.auth.finishDiscordLogin).toHaveBeenCalled();
 });
+
+test('logs error when login fails with debug on', async () => {
+  const config = require('../src/config.js');
+  config.PFC_CONFIG.debug = true;
+  const auth = require('../src/auth.js');
+  auth.finishDiscordLogin.mockImplementation(() => Promise.reject(new Error('fail')));
+  const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+  const err = jest.spyOn(console, 'error').mockImplementation(() => {});
+  window.history.pushState({}, '', '/?code=err');
+  const mods = await loadMain();
+  window.dispatchEvent(new Event('DOMContentLoaded'));
+  await new Promise(r => setTimeout(r, 0));
+  expect(mods.auth.finishDiscordLogin).toHaveBeenCalled();
+  expect(err).toHaveBeenCalled();
+  expect(log).toHaveBeenCalledWith('[MAIN] Booting up...');
+  log.mockRestore();
+  err.mockRestore();
+});

--- a/__tests__/nav.test.js
+++ b/__tests__/nav.test.js
@@ -11,6 +11,7 @@ beforeEach(() => {
   const auth = require('../src/auth.js');
   auth.getUser.mockReset();
   localStorage.clear();
+  global.navigateTo = jest.fn();
   document.body.innerHTML = `
     <button id="login-btn" class="hidden"></button>
     <button id="login-btn-mobile" class="hidden"></button>
@@ -64,4 +65,55 @@ test('hamburger toggle hides and shows menu', async () => {
   expect(menu.classList.contains('hidden')).toBe(false);
   toggle.click();
   expect(menu.classList.contains('hidden')).toBe(true);
+});
+
+test('non-admin user on admin page is redirected', async () => {
+  window.history.pushState({}, '', '/admin.html');
+  localStorage.setItem('jwt', 't');
+  const auth = require('../src/auth.js');
+  auth.getUser.mockReturnValue({ displayName: 'User', roles: [] });
+  const nav = await loadNav();
+  nav.init();
+  await new Promise(r => setTimeout(r, 0));
+  expect(global.navigateTo).toHaveBeenCalledWith('./unauthorized.html');
+});
+
+test('unauthenticated user on admin page is redirected', async () => {
+  window.history.pushState({}, '', '/admin.html');
+  const nav = await loadNav();
+  nav.init();
+  await new Promise(r => setTimeout(r, 0));
+  expect(global.navigateTo).toHaveBeenCalledWith('./unauthorized.html');
+});
+
+test('login-success event reruns nav logic', async () => {
+  localStorage.setItem('jwt', 't');
+  const auth = require('../src/auth.js');
+  auth.getUser.mockReturnValue({ displayName: 'User1', roles: [] });
+  const nav = await loadNav();
+  nav.init();
+  await new Promise(r => setTimeout(r, 0));
+  expect(document.getElementById('display-name').textContent).toBe('User1');
+  auth.getUser.mockReturnValue({ displayName: 'User2', roles: [] });
+  document.dispatchEvent(new Event('login-success'));
+  await new Promise(r => setTimeout(r, 0));
+  expect(document.getElementById('display-name').textContent).toBe('User2');
+});
+
+test('warns when hamburger elements missing', async () => {
+  document.body.innerHTML = `
+    <button id="login-btn" class="hidden"></button>
+    <button id="login-btn-mobile" class="hidden"></button>
+    <button id="logout-btn" class="hidden"></button>
+    <button id="logout-btn-mobile" class="hidden"></button>
+    <p id="user-info" class="hidden"><span id="display-name"></span></p>
+    <a id="admin-link" class="hidden"></a>
+    <a id="admin-link-mobile" class="hidden"></a>
+    <div id="admin-container" class="hidden"></div>
+  `;
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  await loadNav();
+  document.dispatchEvent(new Event('nav-ready'));
+  expect(warn).toHaveBeenCalledWith("[nav] Couldn't find nav-toggle or nav-menu-mobile");
+  warn.mockRestore();
 });


### PR DESCRIPTION
## Summary
- expand nav tests for admin redirects and login success
- test failure path in main.js with debug logging

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6855b6401a98832db568783dd7bd629f